### PR TITLE
Patch for mt-wizard.cgi error on probing NetPBM

### DIFF
--- a/lib/MT/Image/NetPBM.pm
+++ b/lib/MT/Image/NetPBM.pm
@@ -161,7 +161,7 @@ sub convert {
 
 sub _find_pbm {
     my $image = shift;
-    return $image->{__pbm_path} if $image->{__pbm_path};
+    return $image->{__pbm_path} if ref $image and $image->{__pbm_path};
     my @NetPBM = qw( /usr/local/netpbm/bin /usr/local/bin /usr/bin );
     my $pbm;
     for my $path ( MT->config->NetPBMPath, @NetPBM ) {
@@ -174,7 +174,7 @@ sub _find_pbm {
             "You do not have a valid path to the NetPBM tools on your machine."
         )
     ) unless $pbm;
-    $image->{__pbm_path} = $pbm;
+    $image->{__pbm_path} = $pbm if ref $image;
 }
 
 1;


### PR DESCRIPTION
Hi! I ran into a bug running mt-wizard.cgi in its final step, and here's a fix:

```
* During first-time installation, NetPBM was probes using the class only:

    MT::Image::NetPBM->load_driver (lib/MT/App/Wizard.pm line 1072)

  therefore we can't store into its {__pbm_path} without triggering this error:
  "bareword MT::Image::NetPBM cannot be used as hashref under strict 'refs'"

  Workaround this issue by checking for ref($image) before using it as a hash.
```

Many thanks for keeping working on MT!

Cheers,
Audrey
