### PR TITLE
fix typo

### DIFF
--- a/lib/MT/PSGI.pm
+++ b/lib/MT/PSGI.pm
@@ -246,7 +246,7 @@ sub mount_applications {
     }
 
     ## Mount mt-static directory
-    my my $staticurl = $mt->static_path();
+    my $staticurl = $mt->static_path();
     $staticurl =~ s!^https?://[^/]*!!;
     my $staticpath = $mt->static_file_path();
     $urlmap->map( $staticurl,


### PR DESCRIPTION
before:
my my $staticurl = $mt->static_path();

after:
my $staticurl = $mt->static_path();

at lib/MT/PSGI.pm line: 249
