### PR TITLE
Improvement rebuilding speed with caching Publisher->archive_file_for

### DIFF
--- a/lib/MT/Template/ContextHandlers.pm
+++ b/lib/MT/Template/ContextHandlers.pm
@@ -5651,7 +5651,9 @@ B<Example:>
             'p' =>
                 "<mt:PagerBlock><mt:IfCurrentPage><mt:Var name='__value__'></mt:IfCurrentPage></mt:PagerBlock>"
             ,                                        # current page number
+            '_Z' => "<MTArchiveDate format='%Y/%m'>", # year/month, used as default archive map
         );
+        $format =~ s!%y/%m!%_Z!g if defined $format;
         $format =~ s!%([_-]?[A-Za-z])!$f{$1}!g if defined $format;
 
         # now build this template and return result


### PR DESCRIPTION
WeblogPublisher->archive_file_for() is called at rebuilding to generate PermaLink and ArchiveLink very many times.  Here is a patch to cache results of the archive_file_for(), which reduces rebuilding time about 20%.

And to save call MTArchvieDate 2 times in MTFileTemplate, I add a special pattern for "%y/%m" in MTFileTemplate format parser.  "%y/%m" is the special pattern used in default archive map path.

Thanks,
