### PR TITLE
fix broken tools/rebuild-pages url path

### DIFF
--- a/tools/rebuild-pages
+++ b/tools/rebuild-pages
@@ -162,7 +162,7 @@ sub run_rebuild {
                 if ( $res->{status_publishing} ) {
                     ( undef, $url ) =
                       $resp->content() =~ /window.location='(.*)\?(.*)'/;
-                    $url = "http://$hostname/$script_path/" . $mt->AdminScript . "?" . $url;
+                    $url = "http://$hostname$script_path" . $mt->config->AdminScript . "?" . $url;
                 }
                 elsif ( $res->{status_success} ) {
                     logging( "\t" . $at . " built success." . "\n" );


### PR DESCRIPTION
Url built by `tools/rebuild-pages` are broken.
MT class hasn't `AdminScript` method and `$script_path` is sandwiched between the slash, then output `/$script_path/` is `//mt//`.
