### PR TITLE
Change use of abandoned Net::SMTP::TLS module to Net::SMTP::TLS::ButMaintained...

### DIFF
--- a/lib/MT/App/Wizard.pm
+++ b/lib/MT/App/Wizard.pm
@@ -185,10 +185,10 @@ sub init_core_registry {
                 label =>
                     'Net::SMTP::SSL is required to use SMTP Auth over an SSL connection.',
             },
-            'Net::SMTP::TLS' => {
-                link => 'http://search.cpan.org/dist/Net-SMTP-TLS/',
+            'Net::SMTP::TLS::ButMaintained' => {
+                link => 'http://search.cpan.org/dist/Net-SMTP-TLS-ButMaintained/',
                 label =>
-                    'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.',
+                    'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.',
             },
             'IO::Socket::SSL' => {
                 link => 'http://search.cpan.org/dist/IO-Socket-SSL/',

--- a/lib/MT/L10N/de.pm
+++ b/lib/MT/L10N/de.pm
@@ -198,7 +198,7 @@ use vars qw( @ISA %Lexicon );
 	'Net::SMTP is required in order to send mail via an SMTP Server.' => 'Net::SMTP ist für den Versand von E-Mails über SMTP-Server erforderlich.',
 	'This module and its dependencies are required in order to support CRAM-MD5, DIGEST-MD5 or LOGIN SASL mechanisms.' => 'Dieses Modul und seine Abhängigkeiten sind zur Verwendung von CRAM-MD5, DIGEST-MD5 und LOGIN SASL erforderlich.',
 	'Net::SMTP::SSL is required to use SMTP Auth over an SSL connection.' => 'Net::SMTP::SSL ist zur Verwendung von SMTP Auth über SSL erforderlich.',
-	'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TSL ist zur Verwendung von SMTP Auth mit STARTSSL erforderlich.',
+	'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS::ButMaintained ist zur Verwendung von SMTP Auth mit STARTSSL erforderlich.',
 	'IO::Socket::SSL is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'IO::Socket::SSL ist zur Verwendung von SMTP Auth über SSL oder mit STARTSSL erforderlich.',
 	'Net::SSLeay is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'Net::SSLeay ist zur Verwendung von SMTP Auth über SSL oder mit STARTSSL erforderlich.',
 	'This module is used in a test attribute for the MTIf conditional tag.' => 'Dieses Modul ist für ein test-Attribut des MTIf-Befehls erforderlich.',

--- a/lib/MT/L10N/es.pm
+++ b/lib/MT/L10N/es.pm
@@ -198,7 +198,7 @@ use vars qw( @ISA %Lexicon );
 	'Net::SMTP is required in order to send mail via an SMTP Server.' => 'Net::SMTP es necesario para enviar correos vía servidores SMTP.',
 	'This module and its dependencies are required in order to support CRAM-MD5, DIGEST-MD5 or LOGIN SASL mechanisms.' => 'Este módulo y sus dependencias son necesarios para dar soporte a los mecanismos CRAM-MD5, DIGEST-MD5 o LOGIN SASL.',
 	'Net::SMTP::SSL is required to use SMTP Auth over an SSL connection.' => 'Net::SMTP::SSL es necesario para usar autentificación SMTP con una conexión SSL.',
-	'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS es necesario para usar autentificación SMTP con
+	'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS::ButMaintained es necesario para usar autentificación SMTP con
 el protocolo de comunicación STARTTLS.',
 	'IO::Socket::SSL is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'IO::Socket::SSL es necesario para usar autentificación SMTP con una conexión SSL o con el comando STARTTLS.',
 	'Net::SSLeay is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'Net::SSLeay es necesario para usar autentificación SMTP con una conexión SSL o con el comando STARTTLS.',
@@ -854,7 +854,7 @@ que la dirección provista es correcta y le pertenece.',
 	'Test email from Movable Type Configuration Wizard' => 'Mensaje de comprobación del asistente de configuración de Movable Type',
 	'This is the test email sent by your new installation of Movable Type.' => 'Este es el mensaje de comprobación enviado por su nueva instalación de Movable Type.',
 	'Net::SMTP is required in order to send mail using an SMTP server.' => 'Net::SMTP es necesario para enviar correo usando un servidor SMTP.',
-	'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS es necesario para usar autentificación SMTP con
+	'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS::ButMaintained es necesario para usar autentificación SMTP con
 el protocolo de comunicación STARTTLS.',
 	'This module is needed to encode special characters, but this feature can be turned off using the NoHTMLEntities option in mt-config.cgi.' => 'Este módulo es necesario para codificar caracteres especiales, pero se puede desactivar esta característica utilizando la opción NoHTMLEntities en mt-config.cgi.',
 	'This module is needed if you want to use the MT XML-RPC server implementation.' => 'Este módulo es necesario si desea usar la implementación del servidor XML-RCP de Movable Type.',

--- a/lib/MT/L10N/fr.pm
+++ b/lib/MT/L10N/fr.pm
@@ -198,7 +198,7 @@ use vars qw( @ISA %Lexicon );
 	'Net::SMTP is required in order to send mail via an SMTP Server.' => 'Net::SMTP est nécessaire pour envoyer du courriel via un serveur SMTP.',
 	'This module and its dependencies are required in order to support CRAM-MD5, DIGEST-MD5 or LOGIN SASL mechanisms.' => 'Ce module et ses dépendances sont requis pour utiliser les mécanismes CRAM-MD5, DIGEST-MD5 ou LOGIN SASL.',
 	'Net::SMTP::SSL is required to use SMTP Auth over an SSL connection.' => 'Net::SMTP::SSL est requis pour l\'authentification SMTP via une connexion SSL.',
-	'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS est requis pour l\'authentification SMTP par la commande STARTTLS.',
+	'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS::ButMaintained est requis pour l\'authentification SMTP par la commande STARTTLS.',
 	'IO::Socket::SSL is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'IO::Socket::SSL est requis pour l\'authentification SMTP via une connexion SSL ou par la commande STARTTLS.',
 	'Net::SSLeay is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'Net::SSLeay est requis pour l\'authentification SMTP via une connexion SSL ou par la commande STARTTLS.',
 	'This module is used in a test attribute for the MTIf conditional tag.' => 'Ce module est utilisé dans attribut de test pour la balise conditionnelle MTIf.',

--- a/lib/MT/L10N/ja.pm
+++ b/lib/MT/L10N/ja.pm
@@ -198,7 +198,7 @@ use vars qw( @ISA %Lexicon );
 	'Net::SMTP is required in order to send mail via an SMTP Server.' => 'メールの送信にSMTPを利用する場合に必要になります。',
 	'This module and its dependencies are required in order to support CRAM-MD5, DIGEST-MD5 or LOGIN SASL mechanisms.' => 'Authen::SASLとその依存モジュールはCRAM-MD5、DIGEST-MD5又はLOGINをSASLメカニズムとして利用する場合に必要となります。',
 	'Net::SMTP::SSL is required to use SMTP Auth over an SSL connection.' => 'Net::SMTP::SSLはSMTP認証にSSLを利用する場合に必要となります。',
-	'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLSはSMTP認証にSTARTTLSコマンドを利用する場合に必要となります。',
+	'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS::ButMaintainedはSMTP認証にSTARTTLSコマンドを利用する場合に必要となります。',
 	'IO::Socket::SSL is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'IO::Socket::SSLはSMTP認証にSSLまたは、STARTTLSコマンドを利用する場合に必要となります。',
 	'Net::SSLeay is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'Net::SSLeayはSMTP認証にSSLまたは、STARTTLSコマンドを利用する場合に必要となります。',
 	'This module is used in a test attribute for the MTIf conditional tag.' => 'MT:Ifタグの機能で使われます。',

--- a/lib/MT/L10N/nl.pm
+++ b/lib/MT/L10N/nl.pm
@@ -198,7 +198,7 @@ use vars qw( @ISA %Lexicon );
 	'Net::SMTP is required in order to send mail via an SMTP Server.' => 'Net::SMTP is vereist om mail te kunnen versturen via een SMTP server.',
 	'This module and its dependencies are required in order to support CRAM-MD5, DIGEST-MD5 or LOGIN SASL mechanisms.' => 'Deze modules en de modules waar deze van afhangt zijn vereist om CRM-MD5, DIGEST-MD5 of LOGIN SASL te ondersteunen.',
 	'Net::SMTP::SSL is required to use SMTP Auth over an SSL connection.' => 'Net::SMTP::SSL is vereist om SMTP Auth te kunnen gebruiken over een SSL verbinding.',
-	'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS is vereist om SMTP Auth te kunnen gebruiken met het STARTTLS commando.',
+	'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.' => 'Net::SMTP::TLS::ButMaintained is vereist om SMTP Auth te kunnen gebruiken met het STARTTLS commando.',
 	'IO::Socket::SSL is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'IO::Socket::SSL is vereist om SMTP Auth te kunnen gebruiken over een SSL verbinding of om het te kunnen gebruiken met een STARTTLS commando.',
 	'Net::SSLeay is required to use SMTP Auth over an SSL connection, or to use it with a STARTTLS command.' => 'Net::SSLeay is vereist om SMTP Auth te kunnen gebruiken over een SSL verbinding of om het te kunnen gebruiken met een STARTTLS commando.',
 	'This module is used in a test attribute for the MTIf conditional tag.' => 'Deze module wordt gebruikt in een testattribuut voor de MTIf conditionele tag.',

--- a/lib/MT/Mail.pm
+++ b/lib/MT/Mail.pm
@@ -18,7 +18,7 @@ my %SMTPModules = (
     Core => [ 'Net::SMTP', 'MIME::Base64' ],
     Auth => ['Authen::SASL'],
     SSL => [ 'Net::SMTP::SSL', 'IO::Socket::SSL', 'Net::SSLeay' ],
-    TLS => [ 'Net::SMTP::TLS', 'IO::Socket::SSL', 'Net::SSLeay' ],
+    TLS => [ 'Net::SMTP::TLS::ButMaintained', 'IO::Socket::SSL', 'Net::SSLeay' ],
 );
 
 sub send {
@@ -235,7 +235,7 @@ sub _send_mt_smtp {
     my $smtp;
 
     if ($tls) {
-        $smtp = Net::SMTP::TLS->new(
+        $smtp = Net::SMTP::TLS::ButMaintained->new(
             $host,
             Port     => $port,
             User     => $user,

--- a/mt-check.cgi
+++ b/mt-check.cgi
@@ -708,10 +708,10 @@ my @CORE_OPT = (
         )
     ],
 
-    [   'Net::SMTP::TLS',
+    [   'Net::SMTP::TLS::ButMaintained',
         0, 0,
         translate(
-            'Net::SMTP::TLS is required to use SMTP Auth with STARTTLS command.'
+            'Net::SMTP::TLS::ButMaintained is required to use SMTP Auth with STARTTLS command.'
         )
     ],
 


### PR DESCRIPTION
...to resolve "invalid SSL_version specified" error message when sending email with smtpauth/starttls.  bugid:109587

This pull request illustrates the changes necessary for Movable Type to use the Net::SMTP::TLS::ButMaintained perl module as a replacement for the Net::SMTP::TLS perl module without having to rewrite Movable Type's mail code.  The Net::SMTP::TLS perl module is abandoned (no longer actively developed), is not compatible with IO::Socket::SSL >= version 1.70, and should not be used by Movable Type.
