### PR TITLE
Fix for mt:Entries improperly clearing entries stash in multiblog context

### DIFF
--- a/lib/MT/Template/Tags/Entry.pm
+++ b/lib/MT/Template/Tags/Entry.pm
@@ -365,6 +365,13 @@ sub _hdlr_entries {
         $use_stash = 0;
     }
 
+    if ( $ctx->stash('inside_blogs') || $ctx->stash('multiblog_context') ) {
+
+        # In mt:Blogs or mt:Multiblog context; 
+        #   we can't use stashed entries
+        $use_stash = 0;
+    }
+
     my $entries;
     if ($use_stash) {
         $entries = $ctx->stash('entries');
@@ -380,11 +387,6 @@ sub _hdlr_entries {
         if ( !$entry->isa($class) ) {
 
             # class types do not match; we can't use stashed entries
-            undef $entries;
-        }
-        elsif ( $blog_id != $entry->blog_id ) {
-
-            # Blog ID do not match; we can't use stashed entries
             undef $entries;
         }
     }


### PR DESCRIPTION
Fix applied to address issue described in [Case 108989](https://movabletype.fogbugz.com/?108989) improperly clears entries stash under some conditions.

Details of [patch](https://github.com/movabletype/movabletype/commit/677347d969c54158ecf970ae562271788fde5838) applied to mt:Entries code (_hdlr_entries sub) in lib/MT/Template/Tags/Entry.pm, lines 378-391 (MT 5.2.7):

```
      if ( $entries && scalar @$entries ) {
          my $entry = @$entries[0];
          if ( !$entry->isa($class) ) {

              # class types do not match; we can't use stashed entries
              undef $entries;
          }
+        elsif ( $blog_id != $entry->blog_id ) {
+
+            # Blog ID do not match; we can't use stashed entries
+            undef $entries;
+        }
      }
      $entries = undef unless defined $entries && scalar @$entries;
```

In the above code, $entries is the entry stash, $entry is the first entry in the entries stash, and $blog_id is the blog_id in context.

Patch applied to mt:Entries code establishes and enforces improper requirement that first entry in entries stash must belong to blog in context.  If first entry in entries stash does not belong to blog in context, entries stash is cleared.

This causes issues for code such as plugins which pre-populate the entries stash then forward to the mt:Entries handler code.

A specific example is the MT5 fork of the FieldDay plugin.  The mt:_LinkingEntries and mt:_LinkedEntries template tags pre-populate the entries stash and then forward to the mt:Entries handler code for further possible filtering and sorting.

The mt:_LinkingEntries and mt:LinkedEntries tags retrieve linking/linked entries from all blogs in the system if no blog_id argument is supplied.  When no blog_id argument is supplied, the first entry in the entries stash populated by the mt:_LinkingEntries/mt:LinkedEntries tags may or may not be in the blog in context.  There may not even be any entries in the pre-populated entries stash that belong to the blog in context.

The fix applied to the mt:Entries code in [Case 108989](https://movabletype.fogbugz.com/?108989) generally results in the entries stash pre-populated by the mt:_LinkingEntries and mt:LinkedEntries tags being cleared.  The mt:Entries code then proceeds to retrieve entries normally, which results in the mt:_LinkingEntries and mt:LinkedEntries tags behaving as standard mt:Entries tags.

Suggested resolution:

Reverse the patch previously applied, and apply new patch to more narrowly target the original issue.

From lib/MT/Template/Tags/Entry.pm, line 364 (MT 5.2.7):

```
      if ( $use_stash && %fields ) {
          $use_stash = 0;
      }

+    if ( $ctx->stash('inside_blogs') || $ctx->stash('multiblog_context') ) {
+
+        # In mt:Blogs or mt:Multiblog context;
+        #  we can't use stashed entries
+        $use_stash = 0;
+    }
+
      my $entries;
      if ($use_stash) {
          $entries = $ctx->stash('entries');
          if ( !$entries && $at ) {
              my $archiver = MT->publisher->archiver($at);
              if ( $archiver && $archiver->group_based ) {
                  $entries = $archiver->archive_group_entries( $ctx, %$args );
              }
          }
      }
      if ( $entries && scalar @$entries ) {
          my $entry = @$entries[0];
          if ( !$entry->isa($class) ) {

              # class types do not match; we can't use stashed entries
              undef $entries;
          }
-        elsif ( $blog_id != $entry->blog_id ) {
-
-            # Blog ID do not match; we can't use stashed entries
-            undef $entries;
-        }
      }
      $entries = undef unless defined $entries && scalar @$entries;
```

Notes:
1. New patch uses $ctx->stash('inside_blogs') to detect when mt:Entries tag is within an mt:Blogs or mt:Websites tag.
2. New patch uses $ctx->stash('multiblog_context') to detect when mt:Entries tag is within an mt:Multiblog tag.
3. New patch is applied earlier in mt:Entries code than original patch to avoid potentially overwriting a pre-populated entries stash when an archive template is being published.

The patch described above still addresses the issue raised in [Case 108989](https://movabletype.fogbugz.com/?108989), but allows plugins such as the MT5 fork of FieldDay to function as expected.

FB case for this pull request:
[Case 110597](https://movabletype.fogbugz.com/default.asp?110597): mt:Entries improperly clears entries stash in multiblog context
