### PR TITLE
Make the 'gmake me' work even when the command-line name for the make ut...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ dist:
 	perl build/exportmt.pl --local
 
 me:
-	perl build/exportmt.pl --make
+	/usr/bin/env MAKE=${MAKE} perl build/exportmt.pl --make
 
 clean:
 	-rm -rf $(local_js)

--- a/build/Build.pm
+++ b/build/Build.pm
@@ -294,7 +294,7 @@ sub make {
         );
     }
     else {
-        $self->verbose_command('make');
+        $self->verbose_command($ENV{MAKE}? $ENV{MAKE}: 'make');
     }
 
     if ( !$self->{'debug'} && $self->{'workspace!'} ) {


### PR DESCRIPTION
...ility is gmake.

Makefile -- call build/exportmt.pl with the MAKE environment variable set to the execution path of the make utility being used.
build/Build.pm -- instead of hardcoding 'make,' refer to $ENV{MAKE}.
