### PR TITLE
Fixed a not enough arguments.

### DIFF
--- a/mt-static/js/common/Template.js
+++ b/mt-static/js/common/Template.js
@@ -398,7 +398,7 @@ Template.Filter = {
     },
 
 
-    rp: function( string, params ) {
+    rp: function( string, context, params ) {
         if ( ( typeof string != "string" ) && string && string.toString )
             string = string.toString();
 


### PR DESCRIPTION
This PR fixed a below bug.

**REPRO STEPS**
1. Open edit entry screen.
2. Execute below javascript code. ( For example, using console of Google Chrome Developer Tools. )

``` javascript
Template.process('test', { test: 'foo' }, { test: '[#|rp("foo","bar") test#]' });
```

**EXPECTED**
It is output `"bar"`.

**RESULT**
It is output `"foo"`.
