### PR TITLE
Fixed editor mode of codemirror is inappropriate setting.

### DIFF
--- a/tmpl/cms/edit_template.tmpl
+++ b/tmpl/cms/edit_template.tmpl
@@ -839,9 +839,9 @@ var editor_params = {
     mode: "text/html"
 };
 if (options.match('lang:css')) {
-    editor_params['mode'] = 'text/javascript';
-} else if (options.match('lang:javascript')) {
     editor_params['mode'] = 'text/css';
+} else if (options.match('lang:javascript')) {
+    editor_params['mode'] = 'text/javascript';
 }
 
 var editor = CodeMirror.fromTextArea(jQuery('#text').get(0), editor_params);


### PR DESCRIPTION
# When editing css template

**EXPECTED**
Editor mode is css mode.

**RESUILT**
Editor mode is javascript mode.
# When editing javascript template

**EXPECTED**
Editor mode is javascript mode.

**RESUILT**
Editor mode is css mode.
