### PR TITLE
Fixed some DataAPI callback errors.

### DIFF
--- a/lib/MT/CMS/Entry.pm
+++ b/lib/MT/CMS/Entry.pm
@@ -2926,8 +2926,10 @@ sub post_save {
 sub post_delete {
     my ( $eh, $app, $obj ) = @_;
 
-    my $sess_obj = $app->autosave_session_obj;
-    $sess_obj->remove if $sess_obj;
+    if ( $app->can('autosave_session_obj') ) {
+        my $sess_obj = $app->autosave_session_obj;
+        $sess_obj->remove if $sess_obj;
+    }
 
     $app->log(
         {   message => $app->translate(

--- a/lib/MT/CMS/Template.pm
+++ b/lib/MT/CMS/Template.pm
@@ -1848,8 +1848,10 @@ sub post_save {
     my $eh = shift;
     my ( $app, $obj, $original ) = @_;
 
-    my $sess_obj = $app->autosave_session_obj;
-    $sess_obj->remove if $sess_obj;
+    if ( $app->can('autosave_session_obj') ) {
+        my $sess_obj = $app->autosave_session_obj;
+        $sess_obj->remove if $sess_obj;
+    }
 
     my $dynamic = 0;
     my $q       = $app->param;


### PR DESCRIPTION
## REPRO STEPS

### Entry
1. Delete an entry by DataAPI.

### Template
1. Save a template by DataAPI.

## EXPECTED

Error does not occur and a success log is saved.

## RESULT

Get an error (see below) and an error log is saved.
（But delete entry or save template is success.）

```
内部コールバックでエラーが発生しました: Can't locate object method "autosave_session_obj" via package "MT::App::DataAPI" at lib/MT/CMS/Entry.pm line 2929.
```

```
内部コールバックでエラーが発生しました: Can't locate object method "autosave_session_obj" via package "MT::App::DataAPI" at lib/MT/CMS/Template.pm line 1852.
```

## WORKAROUND

- MT 6.1
- DataAPI JavaScript SDK 0.1.0 (Try it with Node.js edition) 

I made this patch referring to 87eeecb2. 