### PR TITLE
Fix Edit Asset link in Entry Asset Manager when asset is from a websi…

### DIFF
--- a/lib/MT/CMS/Asset.pm
+++ b/lib/MT/CMS/Asset.pm
@@ -334,19 +334,21 @@ sub insert {
     if ($extension_message) {
         $tmpl = $app->load_tmpl(
             'dialog/asset_insert.tmpl',
-            {   upload_html => $text || '',
-                edit_field => scalar $app->param('edit_field') || '',
+            {   upload_html       => $text || '',
+                edit_field        => scalar $app->param('edit_field') || '',
                 extension_message => $extension_message,
                 asset_type        => $asset->class,
+                asset_blog_id     => $asset->blog_id,
             },
         );
     }
     else {
         $tmpl = $app->load_tmpl(
             'dialog/asset_insert.tmpl',
-            {   upload_html => $text                            || '',
-                edit_field  => scalar $app->param('edit_field') || '',
-                asset_type  => $asset->class,
+            {   upload_html   => $text                            || '',
+                edit_field    => scalar $app->param('edit_field') || '',
+                asset_type    => $asset->class,
+                asset_blog_id => $asset->blog_id,
             },
         );
     }

--- a/lib/MT/CMS/Entry.pm
+++ b/lib/MT/CMS/Entry.pm
@@ -326,17 +326,19 @@ sub edit {
                 my $asset_1;
                 if ( $asset->class eq 'image' ) {
                     $asset_1 = {
-                        asset_id    => $asset->id,
-                        asset_name  => $asset->file_name,
-                        asset_thumb => $asset->thumbnail_url( Width => 100 ),
-                        asset_type  => $asset->class
+                        asset_id      => $asset->id,
+                        asset_name    => $asset->file_name,
+                        asset_thumb   => $asset->thumbnail_url( Width => 100 ),
+                        asset_type    => $asset->class,
+                        asset_blog_id => $asset->blog_id,
                     };
                 }
                 else {
                     $asset_1 = {
-                        asset_id   => $asset->id,
-                        asset_name => $asset->file_name,
-                        asset_type => $asset->class
+                        asset_id      => $asset->id,
+                        asset_name    => $asset->file_name,
+                        asset_type    => $asset->class,
+                        asset_blog_id => $asset->blog_id,
                     };
                 }
                 push @{$assets}, $asset_1;

--- a/tmpl/cms/dialog/asset_insert.tmpl
+++ b/tmpl/cms/dialog/asset_insert.tmpl
@@ -36,7 +36,7 @@ if (AssetList) {
 
         // create the link to the asset page with asset name as label
         var myAssetLink = window.document.createElement('a');
-        myAssetLink.setAttribute('href', '<mt:var name="script_url">?__mode=view&_type=asset&blog_id=<mt:var name="blog_id">&id=<mt:AssetID>');
+        myAssetLink.setAttribute('href', '<mt:var name="script_url">?__mode=view&_type=asset&blog_id=<mt:var name="asset_blog_id">&id=<mt:AssetID>');
         myAssetLink.setAttribute('class', 'asset-title');
         myAssetLink.appendChild(document.createTextNode('<mt:AssetFileName encode_js="1">'));
 

--- a/tmpl/cms/edit_entry.tmpl
+++ b/tmpl/cms/edit_entry.tmpl
@@ -660,7 +660,7 @@
     <mt:if name="asset_loop">
     <mt:loop name="asset_loop">
       <li id="list-asset-<mt:var name="asset_id">" class="asset-file asset-type-<mt:var name="asset_type" escape="html" lower_case="1">"<mt:if name="asset_thumb"> onmouseover="show('list-image-<mt:var name="asset_id">')" onmouseout="hide('list-image-<mt:var name="asset_id">')"</mt:if>>
-        <a href="<$mt:var name="script_url"$>?__mode=view&_type=asset&blog_id=<mt:var name="blog_id">&id=<mt:var name="asset_id">" class="asset-title">
+        <a href="<$mt:var name="script_url"$>?__mode=view&_type=asset&blog_id=<mt:var name="asset_blog_id">&id=<mt:var name="asset_id">" class="asset-title">
           <mt:var name="asset_name">
         </a>
         <a href="javascript:removeAssetFromList(<mt:var name="asset_id">)" title="<__trans phrase="Remove this asset.">" class="remove-asset icon-remove icon16 action-icon"><__trans phrase="Remove"></a>


### PR DESCRIPTION
…te's child blog. bugid:113297

In a website with child blogs, create/edit an entry. Insert an asset from a child blog. Now, in the Entry Assets Manager, click the link to the asset to go to the Edit Asset screen. You'll note it goes to the blog dashboard, not the Edit Asset screen.

The inserted link contains a URL to the Edit Asset screen, however the link includes a `blog_id` matching the website, not the ID of the child blog where the asset exists.

This commit fixes that bug.