### PR TITLE
Bug fixes for installer hanging and widget HASH issues

### DIFF
--- a/lib/MT/App.pm
+++ b/lib/MT/App.pm
@@ -3448,7 +3448,7 @@ sub load_widgets {
     my $resave_widgets = 0;
     my $widget_set     = $page . ':' . $scope;
 
-    my $widget_store = $user->widgets;
+    my $widget_store = ref($user->widgets) eq 'HASH' ? $user->widgets : {};
     my $widgets;
     $widgets = $widget_store->{$widget_set} if $widget_store;
 
@@ -3515,7 +3515,7 @@ sub load_widgets {
     ) or return;
 
     if ($resave_widgets) {
-        my $widget_store = $user->widgets();
+        my $widget_store = ref($user->widgets()) eq 'HASH' ? $user->widgets : {};
         $widget_store->{$widget_set} = $widgets;
         $user->widgets($widget_store);
         $user->save;
@@ -3730,7 +3730,7 @@ sub load_widget_list {
         :                             'system';
     $scope = $page . ':' . $scope;
 
-    my $user_widgets = $app->user->widgets || {};
+    my $user_widgets = ref($app->user->widgets) eq 'HASH' ? $app->user->widgets : {};
     $user_widgets
         = $user_widgets->{$scope}
         || $app->default_widgets_for_dashboard($scope_type)

--- a/tmpl/cms/upgrade_runner.tmpl
+++ b/tmpl/cms/upgrade_runner.tmpl
@@ -9,7 +9,6 @@
 
 <div class="upgrade">
 <mt:unless name="up_to_date">
-  <script type="text/javascript" src="<mt:var name="static_uri">js/tc.js?v=<mt:var name="mt_version_id" escape="url">"></script>
   <script type="text/javascript" src="<mt:var name="static_uri">js/tc/client.js?v=<mt:var name="mt_version_id" escape="url">"></script>
   <script type="text/javascript" src="<mt:var name="static_uri">jquery/jquery.json.js?v=<mt:var name="mt_version_id" escape="url">"></script>
   <div id="upgrade-container" class="upgrade-process">


### PR DESCRIPTION
The installer hangs as the tc.js library is twice loaded during the
"installer progress" page.
Remvoing the second tc.js load fies this.

The admin login can exit with an static ref error at the point when the
widgets are loaded as the source data can be just a string instead of
hash as needed.
ref() checks are now run on the source data and are empty inited if the
source data is not a HASH.
