### PR TITLE
Avoid infinit sleep on tests

### DIFF
--- a/t/lib/MT/Test.pm
+++ b/t/lib/MT/Test.pm
@@ -87,6 +87,7 @@ our $CORE_TIME;
 BEGIN {
     *CORE::GLOBAL::time
         = sub { my ($a) = @_; $a ? CORE::time + $_[0] : CORE::time };
+    *CORE::GLOBAL::sleep = sub { CORE::sleep(shift) };
 }
 
 # Suppress output when "MailTransfer debug"

--- a/t/lib/MT/Test.pm
+++ b/t/lib/MT/Test.pm
@@ -87,7 +87,6 @@ our $CORE_TIME;
 BEGIN {
     *CORE::GLOBAL::time
         = sub { my ($a) = @_; $a ? CORE::time + $_[0] : CORE::time };
-    *CORE::GLOBAL::sleep = sub { CORE::sleep };
 }
 
 # Suppress output when "MailTransfer debug"


### PR DESCRIPTION
The line causes some tests to be interrupted (when some db is broken or so).
I guess the infinite sleep is not intended.

> http://perldoc.perl.org/functions/sleep.html
> Causes the script to sleep for (integer) EXPR seconds, or forever if no argument is given