### PR TITLE
Skip image driver dependent tests in case of lack of them

### DIFF
--- a/t/09-image-gd-transparency.t
+++ b/t/09-image-gd-transparency.t
@@ -10,19 +10,15 @@ use File::Spec;
 BEGIN {
     eval 'use GD; 1'
         or plan skip_all => 'GD is not installed';
-
-    $ENV{MT_CONFIG} = 'mysql-test.cfg';
 }
 
-use lib qw( lib extlib t/lib );
-use MT::Test;
-use MT::ConfigMgr;
+use lib qw( lib extlib );
 use MT::Image;
 
 my $dir = dirname( dirname( File::Spec->rel2abs(__FILE__) ) );
 my $file = File::Spec->catfile( $dir, qw/ t images test.png / );
 
-my $cfg = MT::ConfigMgr->instance;
+my $cfg = MT->config;
 $cfg->ImageDriver('GD');
 is( $cfg->ImageDriver, 'GD', 'ImageDriver is GD' );
 

--- a/t/09-image-metadata.t
+++ b/t/09-image-metadata.t
@@ -49,16 +49,18 @@ for my $driver (qw/ ImageMagick GD Imager NetPBM /) {
 
         # Remove 'Orientation' tag. (remove all tags)
         MT::Image->remove_metadata($tempfile);
-
-        ok( MT::Image->new( Filename => $tempfile ),
-            'Can load image having no metadata.'
-        );
-        $exif->ExtractInfo($tempfile);
-        ok( !$exif->GetValue($tag),
-            qq{$tag tag has been removed from JPEG file.} );
-        ok( $exif->GetValue('JFIFVersion'),
-            'JFIFVersion tag is stiall remaining.'
-        );
+        
+        SKIP: {
+            my $img = MT::Image->new;
+            skip( "no $driver for image $tempfile", 3 ) unless $img;
+            ok( $img->init( Filename => $tempfile ) );
+            $exif->ExtractInfo($tempfile);
+            ok( !$exif->GetValue($tag),
+                qq{$tag tag has been removed from JPEG file.} );
+            ok( $exif->GetValue('JFIFVersion'),
+                'JFIFVersion tag is stiall remaining.'
+            );
+        }
     };
 }
 

--- a/t/09-image-netpbm-transparency.t
+++ b/t/09-image-netpbm-transparency.t
@@ -7,8 +7,7 @@ use File::Spec;
 use File::Temp qw( tempfile );
 use Test::More;
 
-use lib qw( lib extlib t );
-use MT::ConfigMgr;
+use lib qw( lib extlib );
 use MT::FileMgr;
 use MT::Image;
 
@@ -17,7 +16,7 @@ my $mt_dir = dirname( dirname($file) );
 my $png    = File::Spec->catfile( $mt_dir, 'mt-static', 'images', 'logo',
     'movable-type-logo.png' );
 
-my $cfg = MT::ConfigMgr->instance;
+my $cfg = MT->config;
 $cfg->ImageDriver('NetPBM');
 
 # Skip this test when NetPBM driver is invalid.

--- a/t/62-asset-metadata.t
+++ b/t/62-asset-metadata.t
@@ -119,10 +119,16 @@ for my $driver (qw/ ImageMagick GD Imager NetPBM /) {
             ok( $image->exif->GetValue('JFIFVersion'),
                 'JFIFVersion tag is still remaining.'
             );
-            ok( MT::Image->new( Filename => $image->file_path ),
-                'Read the image having no metadata.' );
-
-            $image->rotate(90);
+            
+            SKIP: {
+                my $mtimg = MT::Image->new;
+                skip( "no $driver for image $tempfile", 1 ) unless $mtimg;
+                ok( $mtimg->init( Filename => $image->file_path ),
+                    'Read the image having no metadata.' );
+                
+                $image->rotate(90);
+            }
+            
             ok( !$image->has_metadata,
                 'Has no metadata after rotating image.' );
         };


### PR DESCRIPTION
Following test fails not being skipped if netpbm driver is missing.

- t/09-image-netpbm-transparency.t

Following tests fail not being skipped if at least a driver is missing.

- t/09-image-metadata.t
- t/62-asset-metadata.t

This PR fixes the issues.

Let me explain the first case a little. Autoloaded MT::ConfigMgr->Setting(...) methods can only overwrite the value of Setting but create new key.

t/09-image-netpbm-transparency.t
```
my $cfg = MT::ConfigMgr->instance;
$cfg->ImageDriver('NetPBM'); # FAILS and fallbacks to ImageMagick
```

In order to set ImageDriver properly you should initialize the config beforehand. The minimal code for the purpose might be MT->config.

```
my $cfg = MT->config;
$cfg->ImageDriver('NetPBM');
```
