### PR TITLE
Fixed bugid:114429

### DIFF
--- a/lib/MT/Template/ContextHandlers.pm
+++ b/lib/MT/Template/ContextHandlers.pm
@@ -4015,7 +4015,9 @@ L<IncludeBlock> tag. If unassigned, the "contents" variable is used.
         # the block (so any variables/context changes made in that template
         # affect the contained template code)
         my $tokens = $ctx->stash('tokens');
+        my $contents = $ctx->{__stash}{vars}{ lc $name };
         local $ctx->{__stash}{vars}{ lc $name } = sub {
+            local $ctx->{__stash}{vars}{ lc $name } = $contents;
             my $builder = $ctx->stash('builder');
             my $html = $builder->build( $ctx, $tokens, $cond );
             die $ctx->error( $builder->errstr ) unless defined $html;


### PR DESCRIPTION
Fixed a problem of self-referencing when using the contents variable in the block of MTIncludeBlock. 

https://movabletype.fogbugz.com/f/cases/114429/MTIncludeBlock

# 事象

MTIncludeBlockブロック中でcontents変数を参照すると自己参照によるエラーが発生する。

# 再現手順

以下のテンプレートを作成し再構築

## test.txtインデックステンプレート

```
<MTIncludeBlock module="module1">
<$MTInclude module="module2"$>
</MTIncludeBlock>
```

## module1テンプレートモジュール

```
===module1===
var contents=<$mt:var name="contents"$>
===module1===
```

## module2テンプレートモジュール

```
===module2===
<mt:setvarblock name="contents">
set by module2
</mt:setvarblock>
<$mt:include module="module3"$>
===module2===
```

## module3テンプレートモジュール

```
===module3===
<$mt:var name="contents"$>
===module3===
```

# 期待する結果

以下の内容のtest.txtを生成

```
===module1===
var contents=
===module2===
===module3===
set by module2
===module3===
===module2===
===module1===
```

# 実際の結果

> テンプレート「test.txt」の再構築中にエラーが発生しました: <mtIncludeBlock>タグでエラーがありました: <mtInclude>タグでエラーがありました: モジュールでお互いがお互いを参照している状態になっています: module2

エラーが発生する。