### PR TITLE
Use more travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ perl:
 
 env:
   matrix:
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
+    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
+    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
+    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
+    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
+    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
     - TEST_COMMAND="./phpunit"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
     - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
     - TEST_COMMAND="./phpunit"
 
+cache:
+  directories:
+    - ./local
+
 services:
   - memcached
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ language: perl
 
 env:
   matrix:
-    - TEST_COMMAND="PERL_HASH_SEED=0 prove t/[0-9]*.t"
-    - TEST_COMMAND="PERL_HASH_SEED=0 prove t/[^0-9]*.t t/mt7 plugins/*/t && ./phpunit"
+    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
+    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
+    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
+    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
+    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
+    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
+    - TEST_COMMAND="./phpunit"
 
 services:
   - memcached
@@ -57,9 +62,11 @@ install:
   # Cannot install Math::GMP 2.12 and 2.13 with Perl 5.8.
   - sudo cpanm --notest --quiet Math::GMP@2.11
 
+  - sudo cpanm App::cpm
+
   # Instal CPAN modules.
   - cp ./t/cpanfile .
-  - travis_retry sudo cpanm --notest --quiet --installdeps .
+  - travis_retry sudo cpm install -g
 
   # Build MT.
   #- SHELL=/bin/bash make me

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - chmod +x phpunit
 
 install:
-  - cpanm -l --notest App::cpm
+  - cpanm --notest App::cpm
 
   # Tests fail with Perl 5.10.
   - cpm install XML::Parser::PerlSAX

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ perl:
 
 env:
   matrix:
-    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
-    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
-    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
-    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
-    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
-    - TEST_COMMAND="prove -Mlocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
     - TEST_COMMAND="./phpunit"
 
 services:
@@ -43,11 +43,13 @@ before_install:
 install:
   - cpanm --notest App::cpm
 
+  - cpm install -g App::Prove::Plugin::MySQLPool
+
   # Tests fail with Perl 5.10.
   - cpm install XML::Parser::PerlSAX
 
   # Use to install patched Coro.
-  - cpanm install LWP::Protocol::https
+  - cpanm --notest --quiet LWP::Protocol::https
 
   # Use patched Coro for Perl 5.22.
   - cpanm -l --notest --quiet https://github.com/rurban/Coro/archive/rel-6.48_01.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ before_install:
   - chmod +x phpunit
 
 install:
-  # Update to install Math::GMP2.11.
-  - cpanm --self-upgrade
-
   # Tests fail with Perl 5.10.
   - cpanm -l --notest --quiet XML::Parser::PerlSAX
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
-sudo: required
 dist: precise
 
 language: perl
+perl:
+  - 5.18
 
 env:
   matrix:
-    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
-    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
-    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
-    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
-    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
-    - TEST_COMMAND="prove -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
+    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
     - TEST_COMMAND="./phpunit"
 
 services:
@@ -35,38 +36,34 @@ addons:
     - unzip
 
 before_install:
-  # Use system Perl.
-  - perlbrew switch-off
-  - PATH=${PATH#/home/travis/perl5/perlbrew/bin:}
-
   # Use PHPUnit 4.8, because PHP version of Travis CI is 5.3.
   - wget -O phpunit https://phar.phpunit.de/phpunit-old.phar
   - chmod +x phpunit
 
 install:
   # Update to install Math::GMP2.11.
-  - sudo cpanm --self-upgrade
+  - cpanm --self-upgrade
 
   # Tests fail with Perl 5.10.
-  - sudo cpanm --notest --quiet XML::Parser::PerlSAX
+  - cpanm -l --notest --quiet XML::Parser::PerlSAX
 
   # Use to install patched Coro.
-  - sudo cpanm --notest --quiet LWP::Protocol::https
+  - cpanm -l --notest --quiet LWP::Protocol::https
 
   # Use patched Coro for Perl 5.22.
-  - sudo cpanm --notest --quiet https://github.com/rurban/Coro/archive/rel-6.48_01.tar.gz
+  - cpanm -l --notest --quiet https://github.com/rurban/Coro/archive/rel-6.48_01.tar.gz
 
   # Tests fail with Perl 5.8 and 5.10.
-  - sudo cpanm --notest --quiet Twiggy
+  - cpanm -l --notest --quiet Twiggy
 
   # Cannot install Math::GMP 2.12 and 2.13 with Perl 5.8.
-  - sudo cpanm --notest --quiet Math::GMP@2.11
+  - cpanm -l --notest --quiet Math::GMP@2.11
 
-  - sudo cpanm App::cpm
+  - cpanm -l --notest App::cpm
 
   # Instal CPAN modules.
   - cp ./t/cpanfile .
-  - travis_retry sudo cpm install -g
+  - travis_retry cpm install -l
 
   # Build MT.
   #- SHELL=/bin/bash make me

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,26 +41,26 @@ before_install:
   - chmod +x phpunit
 
 install:
+  - cpanm -l --notest App::cpm
+
   # Tests fail with Perl 5.10.
-  - cpanm -l --notest --quiet XML::Parser::PerlSAX
+  - cpm install XML::Parser::PerlSAX
 
   # Use to install patched Coro.
-  - cpanm -l --notest --quiet LWP::Protocol::https
+  - cpanm install LWP::Protocol::https
 
   # Use patched Coro for Perl 5.22.
   - cpanm -l --notest --quiet https://github.com/rurban/Coro/archive/rel-6.48_01.tar.gz
 
   # Tests fail with Perl 5.8 and 5.10.
-  - cpanm -l --notest --quiet Twiggy
+  - cpm install Twiggy
 
   # Cannot install Math::GMP 2.12 and 2.13 with Perl 5.8.
-  - cpanm -l --notest --quiet Math::GMP@2.11
-
-  - cpanm -l --notest App::cpm
+  - cpm install Math::GMP@2.11
 
   # Instal CPAN modules.
   - cp ./t/cpanfile .
-  - travis_retry cpm install -l
+  - travis_retry cpm install
 
   # Build MT.
   #- SHELL=/bin/bash make me

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ perl:
 
 env:
   matrix:
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
-    - TEST_COMMAND="prove -Mlocal::lib -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/[^12]*.t"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/1*.t"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/2*.t"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/[^t]*"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib t/mt7/t*"
+    - TEST_COMMAND="prove -Ilocal/lib/perl5 -j4 -PMySQLPool=MT::Test::Env -It/lib plugins/*/t"
     - TEST_COMMAND="./phpunit"
 
 services:
@@ -79,7 +79,7 @@ before_script:
   - rm plugins/MultiBlog/t/02.tags.t
 
 script:
-  - bash -c "${TEST_COMMAND}"
+  - $TEST_COMMAND
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
   - mysql -uroot -e "grant all privileges on mt_test.* to mt@localhost;"
 
   # Some tests need mt-config.cgi.
-  - cp ./t/mysql-test.cfg ./mt-config.cgi
+  #- cp ./t/mysql-test.cfg ./mt-config.cgi
 
   # Skip failed test.
   - rm plugins/MultiBlog/t/02.tags.t

--- a/t/cpanfile
+++ b/t/cpanfile
@@ -84,6 +84,7 @@ requires 'Net::CIDR';
 requires 'Net::IP';
 
 on 'test' => sub {
+    requires 'App::Prove::Plugin::MySQLPool';
     requires 'Date::Parse';
     requires 'DateTime';
     requires 'DateTime::TimeZone';

--- a/t/lib/MT/Test/Env.pm
+++ b/t/lib/MT/Test/Env.pm
@@ -73,6 +73,9 @@ sub write_config {
         }
     }
 
+    my $image_driver = $ENV{MT_TEST_IMAGE_DRIVER} ||
+        ( eval { require Image::Magick } ? 'ImageMagick' : 'Imager' );
+
     # common directives
     my %config = (
         PluginPath => [
@@ -95,6 +98,7 @@ sub write_config {
         StaticFilePath      => 'TEST_ROOT/mt-static',
         EmailAddressMain    => 'mt@localhost',
         WeblogTemplatesPath => 'MT_HOME/default_templates',
+        ImageDriver         => $image_driver,
     );
 
     if ($extra) {
@@ -111,6 +115,7 @@ sub write_config {
             }
         }
     }
+
     $config{$_} = $connect_info{$_} for keys %connect_info;
 
     my $root = $self->{root};


### PR DESCRIPTION
This PR also includes:
* a change to perlbrew perl so that we can add more perls to test (esp. when we make a release)
* a change to use Imager as an image driver, because Image::Magick is harder to install into perlbrew perl
* caching dependencies installed under local/, which makes total testing time shorter
* parallel testing using -j4 and MySQLPool plugin
