### PR TITLE
Fix/delay init request

### DIFF
--- a/lib/MT/App.pm
+++ b/lib/MT/App.pm
@@ -850,7 +850,6 @@ sub init {
             sub { $app->post_run_debug } );
     }
     $app->{vtbl} = $app->registry("methods");
-    $app->init_request(@_);
     return $app;
 }
 

--- a/lib/MT/App/Search.pm
+++ b/lib/MT/App/Search.pm
@@ -18,7 +18,6 @@ sub id {'new_search'}
 sub init {
     my $app = shift;
     $app->SUPER::init(@_) or return;
-    $app->set_no_cache;
     $app->{default_mode} = 'default';
 
     ## process pathinfo
@@ -107,6 +106,8 @@ sub init_request {
         $app->SUPER::init_request(@_);
         $app->mode('tag') if $app->param('tag');
     }
+
+    $app->set_no_cache;
 
     my $cfg = $app->config;
     my $blog_id

--- a/lib/MT/Bootstrap.pm
+++ b/lib/MT/Bootstrap.pm
@@ -191,6 +191,7 @@ sub import {
                 $ENV{FAST_CGI} = 0;
                 $app = $class->new(%param) or die $class->errstr;
                 local $SIG{__WARN__} = sub { $app->trace( $_[0] ) };
+                $app->init_request;
                 $app->run;
             }
         };

--- a/t/143-app.t
+++ b/t/143-app.t
@@ -34,6 +34,7 @@ subtest 'Check transencoding in validate_request_params().' => sub {
 
     local $ENV{CONTENT_TYPE} = 'text/plain; charset=UTF-8';
     my $app = MT->app;
+    $app->init_request;
     $app->param( 'dummy', 'ダミーパラメータ' );
     $app->validate_request_params;
 
@@ -46,6 +47,7 @@ subtest 'If Content-Type has multi paramters' => sub {
     local $ENV{CONTENT_TYPE}
         = 'multipart/form-data; charset=utf-8; boundary=0xKhTmLbOuNdArY-CAF30B04-D79D-4CD9-9B7D-57302B6F9649';
     my $app = MT->app;
+    $app->init_request;
     $app->param( 'dummy', 'ダミーパラメータ' );
     eval { $app->validate_request_params };
 

--- a/t/211-api-resource-objects.t
+++ b/t/211-api-resource-objects.t
@@ -30,6 +30,7 @@ use MT::DataAPI::Resource;
 $test_env->prepare_fixture('db_data');
 
 my $app = MT::App::DataAPI->new;
+$app->init_request;
 MT->set_instance($app);
 $app->user( $app->model('author')->load(1) );
 $app->current_api_version(1);

--- a/t/213-api-resource-objects-disabled-fields.t
+++ b/t/213-api-resource-objects-disabled-fields.t
@@ -32,6 +32,7 @@ use MT::DataAPI::Resource;
 $test_env->prepare_fixture('db_data');
 
 my $app = MT::App::DataAPI->new;
+$app->init_request;
 MT->set_instance($app);
 my $author = $app->model('author')->load(1);
 $app->user($author);

--- a/t/mt_cms_tools.t
+++ b/t/mt_cms_tools.t
@@ -30,6 +30,7 @@ plan tests => 8;
 
     require MT::App::CMS;
     my $app = MT::App::CMS->instance;
+    $app->init_request;
     note( 'Object types are: '
             . join( q{, }, sort keys %{ MT->registry('object_types') } ) );
 


### PR DESCRIPTION
This PR removes ->init_request from ->init, and adds it where necessary (after ->new, and before ->run), even under the CGI environment. This eliminates an unnecessary init_request under persistent environment, and makes it easier to preload stuff.

Third-party plugins/addons/applications/tests that used ->param at the (post_)init phase should also be fixed.