### PR TITLE
Allow to serve files from multiple mt-static directories provided by external plugins

### DIFF
--- a/lib/MT/PSGI.pm
+++ b/lib/MT/PSGI.pm
@@ -282,7 +282,9 @@ sub mount_applications {
     if ( @static_paths > 1 ) {
         require Plack::App::Cascade;
         $static_app = Plack::App::Cascade->new;
+        my %seen;
         for my $static_path (@static_paths) {
+            next if $seen{$static_path}++;
             my $dir_app
                 = Plack::App::Directory->new( { root => $static_path } )
                 ->to_app;


### PR DESCRIPTION
This PR allows to serve files from multiple mt-static directories, namely, from movabletype/mt-static/ and from movabletype-plugins/mt-static/, without merging one into another or both into somewhere else.

