### PR TITLE
Canonicalize JSON encoding

### DIFF
--- a/lib/MT/ContentData.pm
+++ b/lib/MT/ContentData.pm
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 use base qw( MT::Object MT::Revisable );
 
-use JSON  ();
 use POSIX ();
 
 use MT;
@@ -487,7 +486,7 @@ sub data {
     if (@_) {
         my $json;
         if ( ref $_[0] ) {
-            $json = eval { JSON::encode_json( $_[0] ) } || '{}';
+            $json = eval { MT::Util::to_json( $_[0], { utf8 => 1 } ) } || '{}';
         }
         else {
             $json = $_[0];

--- a/lib/MT/ContentType.pm
+++ b/lib/MT/ContentType.pm
@@ -9,8 +9,6 @@ package MT::ContentType;
 use strict;
 use base qw( MT::Object );
 
-use JSON ();
-
 use MT;
 use MT::CategorySet;
 use MT::ContentField;
@@ -191,7 +189,7 @@ sub fields {
     if (@_) {
         my @fields = ref $_[0] eq 'ARRAY' ? @{ $_[0] } : @_;
         my $sorted_fields = _sort_fields( \@fields );
-        my $json = eval { JSON::encode_json($sorted_fields) } || '[]';
+        my $json = eval { MT::Util::to_json($sorted_fields, { utf8 => 1 }) } || '[]';
         $obj->column( 'fields', $json );
     }
     else {

--- a/lib/MT/Core.pm
+++ b/lib/MT/Core.pm
@@ -2173,6 +2173,8 @@ BEGIN {
             'NumberFieldDecimalPlaces' => { default => 5 },
             'NumberFieldMaxValue'      => { default => 2147483647 },
             'NumberFieldMinValue'      => { default => -2147483648 },
+
+            'JSONCanonicalization' => { default => 1 },
         },
         upgrade_functions => \&load_upgrade_fns,
         applications      => {

--- a/lib/MT/Util.pm
+++ b/lib/MT/Util.pm
@@ -2706,7 +2706,7 @@ sub translate_naughty_words {
 
 sub to_json {
     my ( $value, $args ) = @_;
-    unless ( $ENV{MT_SKIP_JSON_CANONICALIZATION} ) {
+    if ( MT->config->JSONCanonicalization ) {
         $args ||= {};
         $args->{canonical} = 1;
     }

--- a/lib/MT/Util.pm
+++ b/lib/MT/Util.pm
@@ -2706,6 +2706,10 @@ sub translate_naughty_words {
 
 sub to_json {
     my ( $value, $args ) = @_;
+    unless ( $ENV{MT_SKIP_JSON_CANONICALIZATION} ) {
+        $args ||= {};
+        $args->{canonical} = 1;
+    }
     require JSON;
     return JSON::to_json( $value, $args );
 }


### PR DESCRIPTION
- This makes it easier to regenerate fixture, and to test/debug json output
- but this also makes it slower to encode json (for now) because to_json doesn't reuse the encoder object (+ canonicalization itself)
- MT_SKIP_JSON_CANONICALIZATION to ignore canonicalization (though YAGNI, maybe for testing?)
- Consider to cache encoder object(s) if only a few fixed options are used