### PR TITLE
Update extlibs

### DIFF
--- a/extlib/CGI.pm
+++ b/extlib/CGI.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 #/;
 
-$CGI::VERSION='4.36';
+$CGI::VERSION='4.38';
 
 use CGI::Util qw(rearrange rearrange_header make_attributes unescape escape expires ebcdic2ascii ascii2ebcdic);
 
@@ -2688,11 +2688,11 @@ sub url {
     my $request_uri =  $self->request_uri || '';
     my $query_str   =  $query ? $self->query_string : '';
 
+    $script_name    =~ s/\?.*$//s; # remove query string
     $request_uri    =~ s/\?.*$//s; # remove query string
     $request_uri    =  unescape($request_uri);
 
     my $uri         =  $rewrite && $request_uri ? $request_uri : $script_name;
-    $uri            =~ s/\?.*$//s; # remove query string
 
 	if ( defined( $ENV{PATH_INFO} ) ) {
 		# IIS sometimes sets PATH_INFO to the same value as SCRIPT_NAME so only sub it out

--- a/extlib/CGI/Carp.pm
+++ b/extlib/CGI/Carp.pm
@@ -327,7 +327,7 @@ use File::Spec;
 
 $main::SIG{__WARN__}=\&CGI::Carp::warn;
 
-$CGI::Carp::VERSION     = '4.36';
+$CGI::Carp::VERSION     = '4.38';
 $CGI::Carp::CUSTOM_MSG  = undef;
 $CGI::Carp::DIE_HANDLER = undef;
 $CGI::Carp::TO_BROWSER  = 1;

--- a/extlib/CGI/Cookie.pm
+++ b/extlib/CGI/Cookie.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use if $] >= 5.019, 'deprecate';
 
-our $VERSION='4.36';
+our $VERSION='4.38';
 
 use CGI::Util qw(rearrange unescape escape);
 use overload '""' => \&as_string, 'cmp' => \&compare, 'fallback' => 1;

--- a/extlib/CGI/Fast.pm
+++ b/extlib/CGI/Fast.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use if $] >= 5.019, 'deprecate';
 
-$CGI::Fast::VERSION='2.12';
+$CGI::Fast::VERSION='2.13';
 
 use CGI;
 use CGI::Carp;

--- a/extlib/CGI/File/Temp.pm
+++ b/extlib/CGI/File/Temp.pm
@@ -3,7 +3,7 @@
 # you use it directly and your code breaks horribly.
 package CGI::File::Temp;
 
-$CGI::File::Temp::VERSION = '4.36';
+$CGI::File::Temp::VERSION = '4.38';
 
 use parent File::Temp;
 use parent Fh;

--- a/extlib/CGI/Pretty.pm
+++ b/extlib/CGI/Pretty.pm
@@ -6,7 +6,7 @@ use warnings;
 use if $] >= 5.019, 'deprecate';
 use CGI ();
 
-$CGI::Pretty::VERSION = '4.36';
+$CGI::Pretty::VERSION = '4.38';
 $CGI::DefaultClass = __PACKAGE__;
 @CGI::Pretty::ISA = qw( CGI );
 

--- a/extlib/CGI/Push.pm
+++ b/extlib/CGI/Push.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 #/;
 
-$CGI::Push::VERSION='4.36';
+$CGI::Push::VERSION='4.38';
 use CGI;
 use CGI::Util 'rearrange';
 @ISA = ('CGI');

--- a/extlib/CGI/Util.pm
+++ b/extlib/CGI/Util.pm
@@ -6,7 +6,7 @@ use if $] >= 5.019, 'deprecate';
 our @EXPORT_OK = qw(rearrange rearrange_header make_attributes unescape escape
         expires ebcdic2ascii ascii2ebcdic);
 
-our $VERSION = '4.36';
+our $VERSION = '4.38';
 
 our $_EBCDIC = "\t" ne "\011";
 

--- a/extlib/Class/Accessor.pm
+++ b/extlib/Class/Accessor.pm
@@ -1,16 +1,14 @@
 package Class::Accessor;
 require 5.00502;
 use strict;
-$Class::Accessor::VERSION = '0.34';
+$Class::Accessor::VERSION = '0.51';
 
 sub new {
-    my($proto, $fields) = @_;
-    my($class) = ref $proto || $proto;
-
-    $fields = {} unless defined $fields;
-
-    # make a copy of $fields.
-    bless {%$fields}, $class;
+    return bless
+        defined $_[1]
+            ? {%{$_[1]}} # make a copy of $fields.
+            : {},
+        ref $_[0] || $_[0];
 }
 
 sub mk_accessors {
@@ -245,7 +243,7 @@ __END__
   Foo->mk_accessors(qw(name role salary));
 
   # or if you prefer a Moose-like interface...
- 
+
   package Foo;
   use Class::Accessor "antlers";
   has name => ( is => "rw", isa => "Str" );
@@ -258,10 +256,10 @@ __END__
 
   my $job = $mp->role;  # gets $mp->{role}
   $mp->salary(400000);  # sets $mp->{salary} = 400000 # I wish
-  
+
   # like my @info = @{$mp}{qw(name role)}
   my @info = $mp->get(qw(name role));
-  
+
   # $mp->{salary} = 400000
   $mp->set('salary', 400000);
 
@@ -311,7 +309,7 @@ The basic set up is very simple:
 Done.  Foo now has simple far(), bar() and car() accessors
 defined.
 
-Alternatively, if you want to follow Damian's I<best practice> guidelines 
+Alternatively, if you want to follow Damian's I<best practice> guidelines
 you can use:
 
     package Foo;
@@ -337,7 +335,7 @@ Currently only the C<is> attribute is supported.
 
 Class::Accessor provides a basic constructor, C<new>.  It generates a
 hash-based object and can be called as either a class method or an
-object method.  
+object method.
 
 =head2 new
 
@@ -422,7 +420,7 @@ it will throw an exception.  It only uses set() and not get().
 
 B<NOTE> I'm not entirely sure why this is useful, but I'm sure someone
 will need it.  If you've found a use, let me know.  Right now it's here
-for orthoginality and because it's easy to implement.
+for orthogonality and because it's easy to implement.
 
     package Foo;
     use base qw(Class::Accessor);
@@ -504,9 +502,9 @@ override this method to change how data is stored by your accessors.
     $value  = $obj->get($key);
     @values = $obj->get(@keys);
 
-get() defines how data is retreived from your objects.
+get() defines how data is retrieved from your objects.
 
-override this method to change how it is retreived.
+override this method to change how it is retrieved.
 
 =head2 make_accessor
 
@@ -522,16 +520,16 @@ get() and set() before you start mucking with make_accessor().
 
     $read_only_accessor = __PACKAGE__->make_ro_accessor($field);
 
-Generates a subroutine refrence which acts as a read-only accessor for
+Generates a subroutine reference which acts as a read-only accessor for
 the given $field.  It only calls get().
 
 Override get() to change the behavior of your accessors.
 
 =head2 make_wo_accessor
 
-    $read_only_accessor = __PACKAGE__->make_wo_accessor($field);
+    $write_only_accessor = __PACKAGE__->make_wo_accessor($field);
 
-Generates a subroutine refrence which acts as a write-only accessor
+Generates a subroutine reference which acts as a write-only accessor
 (mutator) for the given $field.  It only calls set().
 
 Override set() to change the behavior of your accessors.
@@ -588,7 +586,7 @@ Here's an example of generating an accessor for every public field of
 your class.
 
     package Altoids;
-    
+
     use base qw(Class::Accessor Class::Fields);
     use fields qw(curiously strong mints);
     Altoids->mk_accessors( Altoids->show_fields('Public') );
@@ -604,7 +602,7 @@ your class.
     $tin->curiously('Curiouser and curiouser');
     print $tin->{curiously};    # prints 'Curiouser and curiouser'
 
-    
+
     # Subclassing works, too.
     package Mint::Snuff;
     use base qw(Altoids);
@@ -712,7 +710,7 @@ instead of the expected SUPER::email().
 
 =head1 AUTHORS
 
-Copyright 2009 Marty Pauley <marty+perl@kasei.com>
+Copyright 2017 Marty Pauley <marty+perl@martian.org>
 
 This program is free software; you can redistribute it and/or modify it under
 the same terms as Perl itself.  That means either (a) the GNU General Public

--- a/extlib/Fh.pm
+++ b/extlib/Fh.pm
@@ -5,6 +5,6 @@ package Fh;
 use strict;
 use warnings;
 
-$Fh::VERSION = '4.36';
+$Fh::VERSION = '4.38';
 
 1;

--- a/extlib/File/Copy/Recursive.pm
+++ b/extlib/File/Copy/Recursive.pm
@@ -1,6 +1,7 @@
 package File::Copy::Recursive;
 
 use strict;
+
 BEGIN {
     # Keep older versions of Perl from trying to use lexical warnings
     $INC{'warnings.pm'} = "fake warnings entry for < 5.6 perl ($])" if $] < 5.006;
@@ -8,24 +9,26 @@ BEGIN {
 use warnings;
 
 use Carp;
-use File::Copy; 
-use File::Spec; #not really needed because File::Copy already gets it, but for good measure :)
+use File::Copy;
+use File::Spec;    #not really needed because File::Copy already gets it, but for good measure :)
+use Cwd ();
 
-use vars qw( 
-    @ISA      @EXPORT_OK $VERSION  $MaxDepth $KeepMode $CPRFComp $CopyLink 
-    $PFSCheck $RemvBase $NoFtlPth  $ForcePth $CopyLoop $RMTrgFil $RMTrgDir 
-    $CondCopy $BdTrgWrn $SkipFlop  $DirPerms
+use vars qw(
+  @ISA      @EXPORT_OK $VERSION  $MaxDepth $KeepMode $CPRFComp $CopyLink
+  $PFSCheck $RemvBase $NoFtlPth  $ForcePth $CopyLoop $RMTrgFil $RMTrgDir
+  $CondCopy $BdTrgWrn $SkipFlop  $DirPerms
 );
 
 require Exporter;
-@ISA = qw(Exporter);
-@EXPORT_OK = qw(fcopy rcopy dircopy fmove rmove dirmove pathmk pathrm pathempty pathrmdir);
-$VERSION = '0.38';
+@ISA       = qw(Exporter);
+@EXPORT_OK = qw(fcopy rcopy dircopy fmove rmove dirmove pathmk pathrm pathempty pathrmdir rcopy_glob rmove_glob);
+
+$VERSION = '0.40';
 
 $MaxDepth = 0;
 $KeepMode = 1;
-$CPRFComp = 0; 
-$CopyLink = eval { local $SIG{'__DIE__'};symlink '',''; 1 } || 0;
+$CPRFComp = 0;
+$CopyLink = eval { local $SIG{'__DIE__'}; symlink '', ''; 1 } || 0;
 $PFSCheck = 1;
 $RemvBase = 0;
 $NoFtlPth = 0;
@@ -36,354 +39,454 @@ $RMTrgDir = 0;
 $CondCopy = {};
 $BdTrgWrn = 0;
 $SkipFlop = 0;
-$DirPerms = 0777; 
+$DirPerms = 0777;
 
 my $samecheck = sub {
-   return 1 if $^O eq 'MSWin32'; # need better way to check for this on winders...
-   return if @_ != 2 || !defined $_[0] || !defined $_[1];
-   return if $_[0] eq $_[1];
+    return 1 if $^O eq 'MSWin32';    # need better way to check for this on winders...
+    return if @_ != 2 || !defined $_[0] || !defined $_[1];
+    return if $_[0] eq $_[1];
 
-   my $one = '';
-   if($PFSCheck) {
-      $one    = join( '-', ( stat $_[0] )[0,1] ) || '';
-      my $two = join( '-', ( stat $_[1] )[0,1] ) || '';
-      if ( $one eq $two && $one ) {
-          carp "$_[0] and $_[1] are identical";
-          return;
-      }
-   }
+    my $one = '';
+    if ($PFSCheck) {
+        $one = join( '-', ( stat $_[0] )[ 0, 1 ] ) || '';
+        my $two = join( '-', ( stat $_[1] )[ 0, 1 ] ) || '';
+        if ( $one eq $two && $one ) {
+            carp "$_[0] and $_[1] are identical";
+            return;
+        }
+    }
 
-   if(-d $_[0] && !$CopyLoop) {
-      $one    = join( '-', ( stat $_[0] )[0,1] ) if !$one;
-      my $abs = File::Spec->rel2abs($_[1]);
-      my @pth = File::Spec->splitdir( $abs );
-      while(@pth) {
-         my $cur = File::Spec->catdir(@pth);
-         last if !$cur; # probably not necessary, but nice to have just in case :)
-         my $two = join( '-', ( stat $cur )[0,1] ) || '';
-         if ( $one eq $two && $one ) {
-             # $! = 62; # Too many levels of symbolic links
-             carp "Caught Deep Recursion Condition: $_[0] contains $_[1]";
-             return;
-         }
-      
-         pop @pth;
-      }
-   }
+    if ( -d $_[0] && !$CopyLoop ) {
+        $one = join( '-', ( stat $_[0] )[ 0, 1 ] ) if !$one;
+        my $abs = File::Spec->rel2abs( $_[1] );
+        my @pth = File::Spec->splitdir($abs);
+        while (@pth) {
+            if ( $pth[-1] eq '..' ) {    # cheaper than Cwd::realpath() plus we don't want to resolve symlinks at this point, right?
+                pop @pth;
+                pop @pth unless -l File::Spec->catdir(@pth);
+                next;
+            }
+            my $cur = File::Spec->catdir(@pth);
+            last if !$cur;               # probably not necessary, but nice to have just in case :)
+            my $two = join( '-', ( stat $cur )[ 0, 1 ] ) || '';
+            if ( $one eq $two && $one ) {
 
-   return 1;
+                # $! = 62; # Too many levels of symbolic links
+                carp "Caught Deep Recursion Condition: $_[0] contains $_[1]";
+                return;
+            }
+
+            pop @pth;
+        }
+    }
+
+    return 1;
 };
 
 my $glob = sub {
-    my ($do, $src_glob, @args) = @_;
-    
+    my ( $do, $src_glob, @args ) = @_;
+
     local $CPRFComp = 1;
-    
+    require File::Glob;
+
     my @rt;
-    for my $path ( glob($src_glob) ) {
-        my @call = [$do->($path, @args)] or return;
+    for my $path ( File::Glob::bsd_glob($src_glob) ) {
+        my @call = [ $do->( $path, @args ) ] or return;
         push @rt, \@call;
     }
-    
+
     return @rt;
 };
 
 my $move = sub {
-   my $fl = shift;
-   my @x;
-   if($fl) {
-      @x = fcopy(@_) or return;
-   } else {
-      @x = dircopy(@_) or return;
-   }
-   if(@x) {
-      if($fl) {
-         unlink $_[0] or return;
-      } else {
-         pathrmdir($_[0]) or return;
-      }
-      if($RemvBase) {
-         my ($volm, $path) = File::Spec->splitpath($_[0]);
-         pathrm(File::Spec->catpath($volm,$path,''), $ForcePth, $NoFtlPth) or return;
-      }
-   }
-  return wantarray ? @x : $x[0];
+    my $fl = shift;
+    my @x;
+    if ($fl) {
+        @x = fcopy(@_) or return;
+    }
+    else {
+        @x = dircopy(@_) or return;
+    }
+    if (@x) {
+        if ($fl) {
+            unlink $_[0] or return;
+        }
+        else {
+            pathrmdir( $_[0] ) or return;
+        }
+        if ($RemvBase) {
+            my ( $volm, $path ) = File::Spec->splitpath( $_[0] );
+            pathrm( File::Spec->catpath( $volm, $path, '' ), $ForcePth, $NoFtlPth ) or return;
+        }
+    }
+    return wantarray ? @x : $x[0];
 };
 
 my $ok_todo_asper_condcopy = sub {
-    my $org = shift;
+    my $org  = shift;
     my $copy = 1;
-    if(exists $CondCopy->{$org}) {
-        if($CondCopy->{$org}{'md5'}) {
+    if ( exists $CondCopy->{$org} ) {
+        if ( $CondCopy->{$org}{'md5'} ) {
 
         }
-        if($copy) {
+        if ($copy) {
 
         }
     }
     return $copy;
 };
 
-sub fcopy { 
-   $samecheck->(@_) or return;
-   if($RMTrgFil && (-d $_[1] || -e $_[1]) ) {
-      my $trg = $_[1];
-      if( -d $trg ) {
-        my @trgx = File::Spec->splitpath( $_[0] );
-        $trg = File::Spec->catfile( $_[1], $trgx[ $#trgx ] );
-      }
-      $samecheck->($_[0], $trg) or return;
-      if(-e $trg) {
-         if($RMTrgFil == 1) {
-            unlink $trg or carp "\$RMTrgFil failed: $!";
-         } else {
-            unlink $trg or return;
-         }
-      }
-   }
-   my ($volm, $path) = File::Spec->splitpath($_[1]);
-   if($path && !-d $path) {
-      pathmk(File::Spec->catpath($volm,$path,''), $NoFtlPth);
-   }
-   if( -l $_[0] && $CopyLink ) {
-      carp "Copying a symlink ($_[0]) whose target does not exist" 
-          if !-e readlink($_[0]) && $BdTrgWrn;
-      symlink readlink(shift()), shift() or return;
-   } else {  
-      copy(@_) or return;
+sub fcopy {
+    $samecheck->(@_) or return;
+    if ( $RMTrgFil && ( -d $_[1] || -e $_[1] ) ) {
+        my $trg = $_[1];
+        if ( -d $trg ) {
+            my @trgx = File::Spec->splitpath( $_[0] );
+            $trg = File::Spec->catfile( $_[1], $trgx[$#trgx] );
+        }
+        $samecheck->( $_[0], $trg ) or return;
+        if ( -e $trg ) {
+            if ( $RMTrgFil == 1 ) {
+                unlink $trg or carp "\$RMTrgFil failed: $!";
+            }
+            else {
+                unlink $trg or return;
+            }
+        }
+    }
+    my ( $volm, $path ) = File::Spec->splitpath( $_[1] );
+    if ( $path && !-d $path ) {
+        pathmk( File::Spec->catpath( $volm, $path, '' ), $NoFtlPth );
+    }
+    if ( -l $_[0] && $CopyLink ) {
+        my $target = readlink( shift() );
+        ($target) = $target =~ m/(.*)/;    # mass-untaint is OK since we have to allow what the file system does
+        carp "Copying a symlink ($_[0]) whose target does not exist"
+          if !-e $target && $BdTrgWrn;
+        my $new = shift();
+        unlink $new if -l $new;
+        symlink( $target, $new ) or return;
+    }
+    else {
+        copy(@_) or return;
 
-      my @base_file = File::Spec->splitpath($_[0]);
-      my $mode_trg = -d $_[1] ? File::Spec->catfile($_[1], $base_file[ $#base_file ]) : $_[1];
+        my @base_file = File::Spec->splitpath( $_[0] );
+        my $mode_trg = -d $_[1] ? File::Spec->catfile( $_[1], $base_file[$#base_file] ) : $_[1];
 
-      chmod scalar((stat($_[0]))[2]), $mode_trg if $KeepMode;
-   }
-   return wantarray ? (1,0,0) : 1; # use 0's incase they do math on them and in case rcopy() is called in list context = no uninit val warnings
+        chmod scalar( ( stat( $_[0] ) )[2] ), $mode_trg if $KeepMode;
+    }
+    return wantarray ? ( 1, 0, 0 ) : 1;    # use 0's incase they do math on them and in case rcopy() is called in list context = no uninit val warnings
 }
 
-sub rcopy { 
-    if (-l $_[0] && $CopyLink) {
-        goto &fcopy;    
+sub rcopy {
+    if ( -l $_[0] && $CopyLink ) {
+        goto &fcopy;
     }
-    
-    goto &dircopy if -d $_[0] || substr( $_[0], ( 1 * -1), 1) eq '*';
+
+    goto &dircopy if -d $_[0] || substr( $_[0], ( 1 * -1 ), 1 ) eq '*';
     goto &fcopy;
 }
 
 sub rcopy_glob {
-    $glob->(\&rcopy, @_);
+    $glob->( \&rcopy, @_ );
 }
 
 sub dircopy {
-   if($RMTrgDir && -d $_[1]) {
-      if($RMTrgDir == 1) {
-         pathrmdir($_[1]) or carp "\$RMTrgDir failed: $!";
-      } else {
-         pathrmdir($_[1]) or return;
-      }
-   }
-   my $globstar = 0;
-   my $_zero = $_[0];
-   my $_one = $_[1];
-   if ( substr( $_zero, ( 1 * -1 ), 1 ) eq '*') {
-       $globstar = 1;
-       $_zero = substr( $_zero, 0, ( length( $_zero ) - 1 ) );
-   }
+    if ( $RMTrgDir && -d $_[1] ) {
+        if ( $RMTrgDir == 1 ) {
+            pathrmdir( $_[1] ) or carp "\$RMTrgDir failed: $!";
+        }
+        else {
+            pathrmdir( $_[1] ) or return;
+        }
+    }
+    my $globstar = 0;
+    my $_zero    = $_[0];
+    my $_one     = $_[1];
+    if ( substr( $_zero, ( 1 * -1 ), 1 ) eq '*' ) {
+        $globstar = 1;
+        $_zero = substr( $_zero, 0, ( length($_zero) - 1 ) );
+    }
 
-   $samecheck->(  $_zero, $_[1] ) or return;
-   if ( !-d $_zero || ( -e $_[1] && !-d $_[1] ) ) {
-       $! = 20; 
-       return;
-   } 
+    $samecheck->( $_zero, $_[1] ) or return;
+    if ( !-d $_zero || ( -e $_[1] && !-d $_[1] ) ) {
+        $! = 20;
+        return;
+    }
 
-   if(!-d $_[1]) {
-      pathmk($_[1], $NoFtlPth) or return;
-   } else {
-      if($CPRFComp && !$globstar) {
-         my @parts = File::Spec->splitdir($_zero);
-         while($parts[ $#parts ] eq '') { pop @parts; }
-         $_one = File::Spec->catdir($_[1], $parts[$#parts]);
-      }
-   }
-   my $baseend = $_one;
-   my $level   = 0;
-   my $filen   = 0;
-   my $dirn    = 0;
+    if ( !-d $_[1] ) {
+        pathmk( $_[1], $NoFtlPth ) or return;
+    }
+    else {
+        if ( $CPRFComp && !$globstar ) {
+            my @parts = File::Spec->splitdir($_zero);
+            while ( $parts[$#parts] eq '' ) { pop @parts; }
+            $_one = File::Spec->catdir( $_[1], $parts[$#parts] );
+        }
+    }
+    my $baseend = $_one;
+    my $level   = 0;
+    my $filen   = 0;
+    my $dirn    = 0;
 
-   my $recurs; #must be my()ed before sub {} since it calls itself
-   $recurs =  sub {
-      my ($str,$end,$buf) = @_;
-      $filen++ if $end eq $baseend; 
-      $dirn++ if $end eq $baseend;
-      
-      $DirPerms = oct($DirPerms) if substr($DirPerms,0,1) eq '0';
-      mkdir($end,$DirPerms) or return if !-d $end;
-      chmod scalar((stat($str))[2]), $end if $KeepMode;
-      if($MaxDepth && $MaxDepth =~ m/^\d+$/ && $level >= $MaxDepth) {
-         return ($filen,$dirn,$level) if wantarray;
-         return $filen;
-      }
-      $level++;
+    my $recurs;    #must be my()ed before sub {} since it calls itself
+    $recurs = sub {
+        my ( $str, $end, $buf ) = @_;
+        $filen++ if $end eq $baseend;
+        $dirn++  if $end eq $baseend;
 
-      
-      my @files;
-      if ( $] < 5.006 ) {
-          opendir(STR_DH, $str) or return;
-          @files = grep( $_ ne '.' && $_ ne '..', readdir(STR_DH));
-          closedir STR_DH;
-      }
-      else {
-          opendir(my $str_dh, $str) or return;
-          @files = grep( $_ ne '.' && $_ ne '..', readdir($str_dh));
-          closedir $str_dh;
-      }
+        $DirPerms = oct($DirPerms) if substr( $DirPerms, 0, 1 ) eq '0';
+        mkdir( $end, $DirPerms ) or return if !-d $end;
+        if ( $MaxDepth && $MaxDepth =~ m/^\d+$/ && $level >= $MaxDepth ) {
+            chmod scalar( ( stat($str) )[2] ), $end if $KeepMode;
+            return ( $filen, $dirn, $level ) if wantarray;
+            return $filen;
+        }
 
-      for my $file (@files) {
-          my ($file_ut) = $file =~ m{ (.*) }xms;
-          my $org = File::Spec->catfile($str, $file_ut);
-          my $new = File::Spec->catfile($end, $file_ut);
-          if( -l $org && $CopyLink ) {
-              carp "Copying a symlink ($org) whose target does not exist" 
-                  if !-e readlink($org) && $BdTrgWrn;
-              symlink readlink($org), $new or return;
-          } 
-          elsif(-d $org) {
-              $recurs->($org,$new,$buf) if defined $buf;
-              $recurs->($org,$new) if !defined $buf;
-              $filen++;
-              $dirn++;
-          } 
-          else {
-              if($ok_todo_asper_condcopy->($org)) {
-                  if($SkipFlop) {
-                      fcopy($org,$new,$buf) or next if defined $buf;
-                      fcopy($org,$new) or next if !defined $buf;                      
-                  }
-                  else {
-                      fcopy($org,$new,$buf) or return if defined $buf;
-                      fcopy($org,$new) or return if !defined $buf;
-                  }
-                  chmod scalar((stat($org))[2]), $new if $KeepMode;
-                  $filen++;
-              }
-          }
-      }
-      1;
-   };
+        $level++;
 
-   $recurs->($_zero, $_one, $_[2]) or return;
-   return wantarray ? ($filen,$dirn,$level) : $filen;
+        my @files;
+        if ( $] < 5.006 ) {
+            opendir( STR_DH, $str ) or return;
+            @files = grep( $_ ne '.' && $_ ne '..', readdir(STR_DH) );
+            closedir STR_DH;
+        }
+        else {
+            opendir( my $str_dh, $str ) or return;
+            @files = grep( $_ ne '.' && $_ ne '..', readdir($str_dh) );
+            closedir $str_dh;
+        }
+
+        for my $file (@files) {
+            my ($file_ut) = $file =~ m{ (.*) }xms;
+            my $org = File::Spec->catfile( $str, $file_ut );
+            my $new = File::Spec->catfile( $end, $file_ut );
+            if ( -l $org && $CopyLink ) {
+                my $target = readlink($org);
+                ($target) = $target =~ m/(.*)/;    # mass-untaint is OK since we have to allow what the file system does
+                carp "Copying a symlink ($org) whose target does not exist"
+                  if !-e $target && $BdTrgWrn;
+                unlink $new if -l $new;
+                symlink( $target, $new ) or return;
+            }
+            elsif ( -d $org ) {
+                my $rc;
+                if ( !-w $org && $KeepMode ) {
+                    local $KeepMode = 0;
+                    carp "Copying readonly directory ($org); mode of its contents may not be preserved.";
+                    $rc = $recurs->( $org, $new, $buf ) if defined $buf;
+                    $rc = $recurs->( $org, $new ) if !defined $buf;
+                    chmod scalar( ( stat($org) )[2] ), $new;
+                }
+                else {
+                    $rc = $recurs->( $org, $new, $buf ) if defined $buf;
+                    $rc = $recurs->( $org, $new ) if !defined $buf;
+                }
+                if ( !$rc ) {
+                    if ($SkipFlop) {
+                        next;
+                    }
+                    else {
+                        return;
+                    }
+                }
+                $filen++;
+                $dirn++;
+            }
+            else {
+                if ( $ok_todo_asper_condcopy->($org) ) {
+                    if ($SkipFlop) {
+                        fcopy( $org, $new, $buf ) or next if defined $buf;
+                        fcopy( $org, $new ) or next if !defined $buf;
+                    }
+                    else {
+                        fcopy( $org, $new, $buf ) or return if defined $buf;
+                        fcopy( $org, $new ) or return if !defined $buf;
+                    }
+                    chmod scalar( ( stat($org) )[2] ), $new if $KeepMode;
+                    $filen++;
+                }
+            }
+        }
+        $level--;
+        chmod scalar( ( stat($str) )[2] ), $end if $KeepMode;
+        1;
+
+    };
+
+    $recurs->( $_zero, $_one, $_[2] ) or return;
+    return wantarray ? ( $filen, $dirn, $level ) : $filen;
 }
 
-sub fmove { $move->(1, @_) } 
+sub fmove { $move->( 1, @_ ) }
 
-sub rmove { 
-    if (-l $_[0] && $CopyLink) {
-        goto &fmove;    
+sub rmove {
+    if ( -l $_[0] && $CopyLink ) {
+        goto &fmove;
     }
-    
-    goto &dirmove if -d $_[0] || substr( $_[0], ( 1 * -1), 1) eq '*';
+
+    goto &dirmove if -d $_[0] || substr( $_[0], ( 1 * -1 ), 1 ) eq '*';
     goto &fmove;
 }
 
 sub rmove_glob {
-    $glob->(\&rmove, @_);
+    $glob->( \&rmove, @_ );
 }
 
-sub dirmove { $move->(0, @_) }
+sub dirmove { $move->( 0, @_ ) }
 
 sub pathmk {
-   my @parts = File::Spec->splitdir( shift() );
-   my $nofatal = shift;
-   my $pth = $parts[0];
-   my $zer = 0;
-   if(!$pth) {
-      $pth = File::Spec->catdir($parts[0],$parts[1]);
-      $zer = 1;
-   }
-   for($zer..$#parts) {
-      $DirPerms = oct($DirPerms) if substr($DirPerms,0,1) eq '0';
-      mkdir($pth,$DirPerms) or return if !-d $pth && !$nofatal;
-      mkdir($pth,$DirPerms) if !-d $pth && $nofatal;
-      $pth = File::Spec->catdir($pth, $parts[$_ + 1]) unless $_ == $#parts;
-   }
-   1;
-} 
+    my ( $vol, $dir, $file ) = File::Spec->splitpath( shift() );
+    my $nofatal = shift;
+
+    $DirPerms = oct($DirPerms) if substr( $DirPerms, 0, 1 ) eq '0';
+
+    if ( defined($dir) ) {
+        my (@dirs) = File::Spec->splitdir($dir);
+
+        for ( my $i = 0; $i < scalar(@dirs); $i++ ) {
+            my $newdir = File::Spec->catdir( @dirs[ 0 .. $i ] );
+            my $newpth = File::Spec->catpath( $vol, $newdir, "" );
+
+            mkdir( $newpth, $DirPerms ) or return if !-d $newpth && !$nofatal;
+            mkdir( $newpth, $DirPerms ) if !-d $newpth && $nofatal;
+        }
+    }
+
+    if ( defined($file) ) {
+        my $newpth = File::Spec->catpath( $vol, $dir, $file );
+
+        mkdir( $newpth, $DirPerms ) or return if !-d $newpth && !$nofatal;
+        mkdir( $newpth, $DirPerms ) if !-d $newpth && $nofatal;
+    }
+
+    1;
+}
 
 sub pathempty {
-   my $pth = shift; 
+    my $pth = shift;
 
-   return 2 if !-d $pth;
+    my ( $orig_dev, $orig_ino ) = ( lstat $pth )[ 0, 1 ];
+    return 2 if !-d _ || !$orig_dev || !$orig_ino;
 
-   my @names;
-   my $pth_dh;
-   if ( $] < 5.006 ) {
-       opendir(PTH_DH, $pth) or return;
-       @names = grep !/^\.+$/, readdir(PTH_DH);
-   }
-   else {
-       opendir($pth_dh, $pth) or return;
-       @names = grep !/^\.+$/, readdir($pth_dh);       
-   }
-   
-   for my $name (@names) {
-      my ($name_ut) = $name =~ m{ (.*) }xms;
-      my $flpth     = File::Spec->catdir($pth, $name_ut);
+    my $starting_point = Cwd::cwd();
+    my ( $starting_dev, $starting_ino ) = ( lstat $starting_point )[ 0, 1 ];
+    chdir($pth) or Carp::croak("Failed to change directory to “$pth”: $!");
+    $pth = '.';
+    _bail_if_changed( $pth, $orig_dev, $orig_ino );
 
-      if( -l $flpth ) {
-	      unlink $flpth or return; 
-      }
-      elsif(-d $flpth) {
-          pathrmdir($flpth) or return;
-      } 
-      else {
-          unlink $flpth or return;
-      }
-   }
+    my @names;
+    my $pth_dh;
+    if ( $] < 5.006 ) {
+        opendir( PTH_DH, $pth ) or return;
+        @names = grep !/^\.\.?$/, readdir(PTH_DH);
+        closedir PTH_DH;
+    }
+    else {
+        opendir( $pth_dh, $pth ) or return;
+        @names = grep !/^\.\.?$/, readdir($pth_dh);
+        closedir $pth_dh;
+    }
+    _bail_if_changed( $pth, $orig_dev, $orig_ino );
 
-   if ( $] < 5.006 ) {
-       closedir PTH_DH;
-   }
-   else {
-       closedir $pth_dh;
-   }
-   
-   1;
+    for my $name (@names) {
+        my ($name_ut) = $name =~ m{ (.*) }xms;
+        my $flpth = File::Spec->catdir( $pth, $name_ut );
+
+        if ( -l $flpth ) {
+            _bail_if_changed( $pth, $orig_dev, $orig_ino );
+            unlink $flpth or return;
+        }
+        elsif ( -d $flpth ) {
+            _bail_if_changed( $pth, $orig_dev, $orig_ino );
+            pathrmdir($flpth) or return;
+        }
+        else {
+            _bail_if_changed( $pth, $orig_dev, $orig_ino );
+            unlink $flpth or return;
+        }
+    }
+
+    chdir($starting_point) or Carp::croak("Failed to change directory to “$starting_point”: $!");
+    _bail_if_changed( ".", $starting_dev, $starting_ino );
+
+    return 1;
 }
 
 sub pathrm {
-   my $path = shift;
-   return 2 if !-d $path;
-   my @pth = File::Spec->splitdir( $path );
-   my $force = shift;
+    my ( $path, $force, $nofail ) = @_;
 
-   while(@pth) { 
-      my $cur = File::Spec->catdir(@pth);
-      last if !$cur; # necessary ??? 
-      if(!shift()) {
-         pathempty($cur) or return if $force;
-         rmdir $cur or return;
-      } 
-      else {
-         pathempty($cur) if $force;
-         rmdir $cur;
-      }
-      pop @pth;
-   }
-   1;
+    my ( $orig_dev, $orig_ino ) = ( lstat $path )[ 0, 1 ];
+    return 2 if !-d _ || !$orig_dev || !$orig_ino;
+
+    my @pth = File::Spec->splitdir($path);
+
+    my %fs_check;
+    my $aggregate_path;
+    for my $part (@pth) {
+        $aggregate_path = defined $aggregate_path ? File::Spec->catdir( $aggregate_path, $part ) : $part;
+        $fs_check{$aggregate_path} = [ ( lstat $aggregate_path )[ 0, 1 ] ];
+    }
+
+    while (@pth) {
+        my $cur = File::Spec->catdir(@pth);
+        last if !$cur;    # necessary ???
+
+        if ($force) {
+            _bail_if_changed( $cur, $fs_check{$cur}->[0], $fs_check{$cur}->[1] );
+            if ( !pathempty($cur) ) {
+                return unless $nofail;
+            }
+        }
+        _bail_if_changed( $cur, $fs_check{$cur}->[0], $fs_check{$cur}->[1] );
+        if ($nofail) {
+            rmdir $cur;
+        }
+        else {
+            rmdir $cur or return;
+        }
+        pop @pth;
+    }
+
+    return 1;
 }
 
 sub pathrmdir {
     my $dir = shift;
-    if( -e $dir ) {
+    if ( -e $dir ) {
         return if !-d $dir;
     }
     else {
         return 2;
     }
 
+    my ( $orig_dev, $orig_ino ) = ( lstat $dir )[ 0, 1 ];
+    return 2 if !$orig_dev || !$orig_ino;
+
     pathempty($dir) or return;
-    
+    _bail_if_changed( $dir, $orig_dev, $orig_ino );
     rmdir $dir or return;
+
+    return 1;
+}
+
+sub _bail_if_changed {
+    my ( $path, $orig_dev, $orig_ino ) = @_;
+
+    my ( $cur_dev, $cur_ino ) = ( lstat $path )[ 0, 1 ];
+
+    if ( !defined $cur_dev || !defined $cur_ino ) {
+        $cur_dev ||= "undef(path went away?)";
+        $cur_ino ||= "undef(path went away?)";
+    }
+    else {
+        $path = Cwd::abs_path($path);
+    }
+
+    if ( $orig_dev ne $cur_dev || $orig_ino ne $cur_ino ) {
+        local $Carp::CarpLevel += 1;
+        Carp::croak("directory $path changed: expected dev=$orig_dev ino=$orig_ino, actual dev=$cur_dev ino=$cur_ino, aborting");
+    }
 }
 
 1;
@@ -421,38 +524,38 @@ None by default. But you can export all the functions as in the example above an
 
 This function uses File::Copy's copy() function to copy a file but not a directory. Any directories are recursively created if need be.
 One difference to File::Copy::copy() is that fcopy attempts to preserve the mode (see Preserving Mode below)
-The optional $buf in the synopsis if the same as File::Copy::copy()'s 3rd argument
-returns the same as File::Copy::copy() in scalar context and 1,0,0 in list context to accomidate rcopy()'s list context on regular files. (See below for more info)
+The optional $buf in the synopsis is the same as File::Copy::copy()'s 3rd argument.
+This function returns the same as File::Copy::copy() in scalar context and 1,0,0 in list context to accomodate rcopy()'s list context on regular files. (See below for more info)
 
 =head2 dircopy()
 
 This function recursively traverses the $orig directory's structure and recursively copies it to the $new directory.
-$new is created if necessary (multiple non existant directories is ok (IE foo/bar/baz). The script logically and portably creates all of them if necessary).
+$new is created if necessary (multiple non existent directories is ok (i.e. foo/bar/baz). The script logically and portably creates all of them if necessary).
 It attempts to preserve the mode (see Preserving Mode below) and 
-by default it copies all the way down into the directory, (see Managing Depth) below.
+by default it copies all the way down into the directory (see Managing Depth, below).
 If a directory is not specified it croaks just like fcopy croaks if its not a file that is specified.
 
-returns true or false, for true in scalar context it returns the number of files and directories copied,
-In list context it returns the number of files and directories, number of directories only, depth level traversed.
+This function returns true or false: for true in scalar context it returns the number of files and directories copied,
+whereas in list context it returns the number of files and directories, number of directories only, depth level traversed.
 
   my $num_of_files_and_dirs = dircopy($orig,$new);
   my($num_of_files_and_dirs,$num_of_dirs,$depth_traversed) = dircopy($orig,$new);
   
-Normally it stops and return's if a copy fails, to continue on regardless set $File::Copy::Recursive::SkipFlop to true.
+Normally it stops and returns if a copy fails. To continue on regardless, set $File::Copy::Recursive::SkipFlop to true.
 
     local $File::Copy::Recursive::SkipFlop = 1;
 
-That way it will copy everythgingit can ina directory and won't stop because of permissions, etc...
+That way it will copy everythging it can in a directory and won't stop because of permissions, etc...
 
 =head2 rcopy()
 
-This function will allow you to specify a file *or* directory. It calls fcopy() if its a file and dircopy() if its a directory.
+This function will allow you to specify a file *or* a directory. It calls fcopy() if you passed file and dircopy() if you passed a directory.
 If you call rcopy() (or fcopy() for that matter) on a file in list context, the values will be 1,0,0 since no directories and no depth are used. 
-This is important becasue if its a directory in list context and there is only the initial directory the return value is 1,1,1.
+This is important because if it's a directory in list context and there is only the initial directory the return value is 1,1,1.
 
 =head2 rcopy_glob()
 
-This function lets you specify a pattern suitable for perl's glob() as the first argument. Subsequently each path returned by perl's glob() gets rcopy()ied.
+This function lets you specify a pattern suitable for perl's File::Glob::bsd_glob() as the first argument. Subsequently each path returned by perl's File::Glob::bsd_glob() gets rcopy()ied.
 
 It returns and array whose items are array refs that contain the return value of each rcopy() call.
 
@@ -499,21 +602,21 @@ Default is false. When set to true it calls pathempty() before any directories a
 
 Default is false. If set to true  rmdir(), mkdir(), and pathempty() calls in pathrm() and pathmk() do not return() on failure.
 
-If its set to true they just silently go about their business regardless. This isn't a good idea but its there if you want it.
+If its set to true they just silently go about their business regardless. This isn't a good idea but it's there if you want it.
 
 =head3 $DirPerms
 
 Mode to pass to any mkdir() calls. Defaults to 0777 as per umask()'s POD. Explicitly having this allows older perls to be able to use FCR and might add a bit of flexibility for you.
 
-Any value you set it to should be suitable for oct()
+Any value you set it to should be suitable for oct().
 
 =head3 Path functions
 
-These functions exist soley because they were necessary for the move and copy functions to have the features they do and not because they are of themselves the purpose of this module. That being said, here is how they work so you can understand how the copy and move funtions work and use them by themselves if you wish.
+These functions exist solely because they were necessary for the move and copy functions to have the features they do and not because they are of themselves the purpose of this module. That being said, here is how they work so you can understand how the copy and move functions work and use them by themselves if you wish.
 
 =head4 pathrm()
 
-Removes a given path recursively. It removes the *entire* path so be carefull!!!
+Removes a given path recursively. It removes the *entire* path so be careful!!!
 
 Returns 2 if the given path is not a directory.
 
@@ -544,7 +647,7 @@ An optional third argument acts like $File::Copy::Recursive::NoFtlPth, again pro
 
 =head4 pathempty()
 
-Recursively removes the given directory's contents so it is empty. returns 2 if argument is not a directory, 1 on successfully emptying the directory.
+Recursively removes the given directory's contents so it is empty. Returns 2 if the given argument is not a directory, 1 on successfully emptying the directory.
 
    File::Copy::Recursive::pathempty($pth) or die $!;
    # $pth is now an empty directory
@@ -560,7 +663,7 @@ An optional second argument if true acts just like $File::Copy::Recursive::NoFtl
 =head4 pathrmdir()
 
 Same as rmdir() but it calls pathempty() first to recursively empty it first since rmdir can not remove a directory with contents.
-Just removes the top directory the path given instead of the entire path like pathrm(). Return 2 if given argument does not exist (IE its already gone). Return false if it exists but is not a directory.
+Just removes the top directory the path given instead of the entire path like pathrm(). Returns 2 if the given argument does not exist (i.e. it's already gone). Returns false if it exists but is not a directory.
 
 =head2 Preserving Mode
 
@@ -578,9 +681,9 @@ to a whole number greater than 0.
 =head2 SymLinks
 
 If your system supports symlinks then symlinks will be copied as symlinks instead of as the target file.
-Perl's symlink() is used instead of File::Copy's copy()
+Perl's symlink() is used instead of File::Copy's copy().
 You can customize this behavior by setting $File::Copy::Recursive::CopyLink to a true or false value.
-It is already set to true or false dending on your system's support of symlinks so you can check it with an if statement to see how it will behave:
+It is already set to true or false depending on your system's support of symlinks so you can check it with an if statement to see how it will behave:
 
     if($File::Copy::Recursive::CopyLink) {
         print "Symlinks will be preserved\n";
@@ -588,7 +691,7 @@ It is already set to true or false dending on your system's support of symlinks 
         print "Symlinks will not be preserved because your system does not support it\n";
     }
 
-If symlinks are being copied you can set $File::Copy::Recursive::BdTrgWrn to true to make it carp when it copies a link whose target does not exist. Its false by default.
+If symlinks are being copied you can set $File::Copy::Recursive::BdTrgWrn to true to make it carp when it copies a link whose target does not exist. It's false by default.
 
     local $File::Copy::Recursive::BdTrgWrn  = 1;
 
@@ -610,11 +713,11 @@ This can be done by setting $File::Copy::Recursive::RMTrgFil or $File::Copy::Rec
     dircopy($orig, $target) or die $!;
     # if it fails it does your "or die"
 
-This should be unnecessary most of the time but its there if you need it :)
+This should be unnecessary most of the time but it's there if you need it :)
 
 =head2 Turning off stat() check
 
-By default the files or directories are checked to see if they are the same (IE linked, or two paths (absolute/relative or different relative paths) to the same file) by comparing the file's stat() info. 
+By default the files or directories are checked to see if they are the same (i.e. linked, or two paths (absolute/relative or different relative paths) to the same file) by comparing the file's stat() info. 
 It's a very efficient check that croaks if they are and shouldn't be turned off but if you must for some weird reason just set $File::Copy::Recursive::PFSCheck to a false value. ("PFS" stands for "Physical File System")
 
 =head2 Emulating cp -rf dir1/ dir2/
@@ -627,7 +730,7 @@ NOTE: This only emulates -f in the sense that it does not prompt. It does not re
 If you need to do that then use the variables $RMTrgFil and $RMTrgDir described in "Removing existing target file or directory before copying" above.
 
 That means that if $dir2 exists it puts the contents into $dir2/$dir1 instead of $dir2 just like cp -rf.
-If $dir2 does not exist then the contents go into $dir2 like normal (also like cp -rf)
+If $dir2 does not exist then the contents go into $dir2 like normal (also like cp -rf).
 
 So assuming 'foo/file':
 
@@ -651,7 +754,7 @@ You can also specify a star for cp -rf glob type behavior:
     # if bar does not exist the result is bar/file
     # if bar does exist the result is bar/file
 
-NOTE: The '*' is only like cp -rf foo/* and *DOES NOT EXPAND PARTIAL DIRECTORY NAMES LIKE YOUR SHELL DOES* (IE not like cp -rf fo* to copy foo/*)
+NOTE: The '*' is only like cp -rf foo/* and *DOES NOT EXPAND PARTIAL DIRECTORY NAMES LIKE YOUR SHELL DOES* (i.e. not like cp -rf fo* to copy foo/*).
 
 =head2 Allowing Copy Loops
 
@@ -663,9 +766,9 @@ type behavior set $File::Copy::Recursive::CopyLoop to true.
 
 This is false by default so that a check is done to see if the source directory will contain the target directory and croaks to avoid this problem.
 
-If you ever find a situation where $CopyLoop = 1 is desirable let me know (IE its a bad bad idea but is there if you want it)
+If you ever find a situation where $CopyLoop = 1 is desirable let me know. (i.e. it's a bad bad idea but is there if you want it)
 
-(Note: On Windows this was necessary since it uses stat() to detemine samedness and stat() is essencially useless for this on Windows. 
+(Note: On Windows this was necessary since it uses stat() to determine sameness and stat() is essentially useless for this on Windows. 
 The test is now simply skipped on Windows but I'd rather have an actual reliable check if anyone in Microsoft land would care to share)
 
 =head1 SEE ALSO
@@ -680,7 +783,7 @@ Tests will be easier to do with the new interface and hence the testing focus wi
 
 The old interface will work, it just won't be brought in until it is used, so it will add no overhead for users of the new interface.
 
-I'll add this after the latest verision has been out for a while with no new features or issues found :)
+I'll add this after the latest version has been out for a while with no new features or issues found :)
 
 =head1 AUTHOR
 

--- a/extlib/HTTP/Config.pm
+++ b/extlib/HTTP/Config.pm
@@ -1,7 +1,9 @@
 package HTTP::Config;
-$HTTP::Config::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 use URI;
 
@@ -243,7 +245,7 @@ HTTP::Config - Configuration for request and response objects
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 
@@ -297,7 +299,7 @@ You can either pass separate key/value pairs or a hash reference.
 =item $conf->remove( %spec )
 
 Removes (and returns) the entries that have matches for all the key/value pairs in %spec.
-If %spec is empty this will match all entries; so it will empty the configuation object.
+If %spec is empty this will match all entries; so it will empty the configuration object.
 
 =item $conf->matching( $uri, $request, $response )
 

--- a/extlib/HTTP/Headers.pm
+++ b/extlib/HTTP/Headers.pm
@@ -1,7 +1,9 @@
 package HTTP::Headers;
-$HTTP::Headers::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 use Carp ();
 
@@ -473,7 +475,7 @@ HTTP::Headers - Class encapsulating HTTP Message headers
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 

--- a/extlib/HTTP/Headers/Auth.pm
+++ b/extlib/HTTP/Headers/Auth.pm
@@ -1,7 +1,9 @@
 package HTTP::Headers::Auth;
-$HTTP::Headers::Auth::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 use HTTP::Headers;
 
@@ -109,7 +111,7 @@ HTTP::Headers::Auth
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 AUTHOR
 

--- a/extlib/HTTP/Headers/ETag.pm
+++ b/extlib/HTTP/Headers/ETag.pm
@@ -1,7 +1,9 @@
 package HTTP::Headers::ETag;
-$HTTP::Headers::ETag::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 require HTTP::Date;
 
@@ -105,7 +107,7 @@ HTTP::Headers::ETag
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 AUTHOR
 

--- a/extlib/HTTP/Headers/Util.pm
+++ b/extlib/HTTP/Headers/Util.pm
@@ -1,7 +1,9 @@
 package HTTP::Headers::Util;
-$HTTP::Headers::Util::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 use base 'Exporter';
 
@@ -101,7 +103,7 @@ HTTP::Headers::Util - Header value parsing utility functions
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 

--- a/extlib/HTTP/Message.pm
+++ b/extlib/HTTP/Message.pm
@@ -1,7 +1,9 @@
 package HTTP::Message;
-$HTTP::Message::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 require HTTP::Headers;
 require Carp;
@@ -428,7 +430,7 @@ sub decodable
     };
     eval {
         require IO::Uncompress::Bunzip2;
-        push(@enc, "x-bzip2");
+        push(@enc, "x-bzip2", "bzip2");
     };
     # we don't care about announcing the 'identity', 'base64' and
     # 'quoted-printable' stuff
@@ -460,7 +462,7 @@ sub encode
 
     my $content = $self->content;
     for my $encoding (@enc) {
-	if ($encoding eq "identity") {
+	if ($encoding eq "identity" || $encoding eq "none") {
 	    # nothing to do
 	}
 	elsif ($encoding eq "base64") {
@@ -481,7 +483,7 @@ sub encode
 		or die "Can't deflate content: $IO::Compress::Deflate::DeflateError";
 	    $content = $output;
 	}
-	elsif ($encoding eq "x-bzip2") {
+	elsif ($encoding eq "x-bzip2" || $encoding eq "bzip2") {
 	    require IO::Compress::Bzip2;
 	    my $output;
 	    IO::Compress::Bzip2::bzip2(\$content, \$output)
@@ -779,7 +781,7 @@ HTTP::Message - HTTP style message (base class)
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 

--- a/extlib/HTTP/Request.pm
+++ b/extlib/HTTP/Request.pm
@@ -1,7 +1,9 @@
 package HTTP::Request;
-$HTTP::Request::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 use base 'HTTP::Message';
 
@@ -18,8 +20,9 @@ sub new
 sub parse
 {
     my($class, $str) = @_;
+    Carp::carp('Undefined argument to parse()') if $^W && ! defined $str;
     my $request_line;
-    if ($str =~ s/^(.*)\n//) {
+    if (defined $str && $str =~ s/^(.*)\n//) {
 	$request_line = $1;
     }
     else {
@@ -28,10 +31,12 @@ sub parse
     }
 
     my $self = $class->SUPER::parse($str);
-    my($method, $uri, $protocol) = split(' ', $request_line);
-    $self->method($method) if defined($method);
-    $self->uri($uri) if defined($uri);
-    $self->protocol($protocol) if $protocol;
+    if (defined $request_line) {
+        my($method, $uri, $protocol) = split(' ', $request_line);
+        $self->method($method);
+        $self->uri($uri) if defined($uri);
+        $self->protocol($protocol) if $protocol;
+    }
     $self;
 }
 
@@ -140,7 +145,7 @@ HTTP::Request - HTTP style request message
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 
@@ -231,6 +236,90 @@ Method returning a textual representation of the request.
 
 =back
 
+=head1 EXAMPLES
+
+Creating requests to be sent with L<LWP::UserAgent> or others can be easy. Here
+are a few examples.
+
+=head2 Simple POST
+
+Here, we'll create a simple POST request that could be used to send JSON data
+to an endpoint.
+
+    #!/usr/bin/env perl
+
+    use strict;
+    use warnings;
+
+    use Encode qw(encode_utf8);
+    use HTTP::Request ();
+    use JSON::MaybeXS qw(encode_json);
+
+    my $url = 'https://www.example.com/api/user/123';
+    my $header = ['Content-Type' => 'application/json; charset=UTF-8'];
+    my $data = {foo => 'bar', baz => 'quux'};
+    my $encoded_data = encode_utf8(encode_json($data));
+
+    my $r = HTTP::Request->new('POST', $url, $header, $encoded_data);
+    # at this point, we could send it via LWP::UserAgent
+    # my $ua = LWP::UserAgent->new();
+    # my $res = $ua->request($r);
+
+=head2 Batch POST Request
+
+Some services, like Google, allow multiple requests to be sent in one batch.
+L<https://developers.google.com/drive/v3/web/batch> for example. Using the
+C<add_part> method from L<HTTP::Message> makes this simple.
+
+    #!/usr/bin/env perl
+
+    use strict;
+    use warnings;
+
+    use Encode qw(encode_utf8);
+    use HTTP::Request ();
+    use JSON::MaybeXS qw(encode_json);
+
+    my $auth_token = 'auth_token';
+    my $batch_url = 'https://www.googleapis.com/batch';
+    my $url = 'https://www.googleapis.com/drive/v3/files/fileId/permissions?fields=id';
+    my $url_no_email = 'https://www.googleapis.com/drive/v3/files/fileId/permissions?fields=id&sendNotificationEmail=false';
+
+    # generate a JSON post request for one of the batch entries
+    my $req1 = build_json_request($url, {
+        emailAddress => 'example@appsrocks.com',
+        role => "writer",
+        type => "user",
+    });
+
+    # generate a JSON post request for one of the batch entries
+    my $req2 = build_json_request($url_no_email, {
+        domain => "appsrocks.com",
+        role => "reader",
+        type => "domain",
+    });
+
+    # generate a multipart request to send all of the other requests
+    my $r = HTTP::Request->new('POST', $batch_url, [
+        'Accept-Encoding' => 'gzip',
+        # if we don't provide a boundary here, HTTP::Message will generate
+        # one for us. We could use UUID::uuid() here if we wanted.
+        'Content-Type' => 'multipart/mixed; boundary=END_OF_PART'
+    ]);
+
+    # add the two POST requests to the main request
+    $r->add_part($req1, $req2);
+    # at this point, we could send it via LWP::UserAgent
+    # my $ua = LWP::UserAgent->new();
+    # my $res = $ua->request($r);
+    exit();
+
+    sub build_json_request {
+        my ($url, $href) = @_;
+        my $header = ['Authorization' => "Bearer $auth_token", 'Content-Type' => 'application/json; charset=UTF-8'];
+        return HTTP::Request->new('POST', $url, $header, encode_utf8(encode_json($href)));
+    }
+
 =head1 SEE ALSO
 
 L<HTTP::Headers>, L<HTTP::Message>, L<HTTP::Request::Common>,
@@ -253,4 +342,3 @@ __END__
 
 
 #ABSTRACT: HTTP style request message
-

--- a/extlib/HTTP/Request/Common.pm
+++ b/extlib/HTTP/Request/Common.pm
@@ -1,7 +1,9 @@
 package HTTP::Request::Common;
-$HTTP::Request::Common::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 our $DYNAMIC_FILE_UPLOAD ||= 0;  # make it defined (don't know why)
 
@@ -215,7 +217,7 @@ sub form_data   # RFC1867
 		    # or perhaps a file in the /proc file system where
 		    # stat may return a 0 size even though reading it
 		    # will produce data.  So we cannot make
-		    # a Content-Length header.  
+		    # a Content-Length header.
 		    undef $length;
 		    last;
 		}
@@ -259,7 +261,7 @@ sub form_data   # RFC1867
 		}
 		if ($buflength) {
 		    defined $length && ($length -= $buflength);
-		    return $buf 
+		    return $buf
 	    	}
 	    }
 	};
@@ -310,7 +312,7 @@ HTTP::Request::Common - Construct common HTTP::Request objects
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 
@@ -318,13 +320,19 @@ version 6.13
   $ua = LWP::UserAgent->new;
   $ua->request(GET 'http://www.sn.no/');
   $ua->request(POST 'http://somewhere/foo', [foo => bar, bar => foo]);
+  $ua->request(PATCH 'http://somewhere/foo', [foo => bar, bar => foo]);
+  $ua->request(PUT 'http://somewhere/foo', [foo => bar, bar => foo]);
 
 =head1 DESCRIPTION
 
-This module provide functions that return newly created C<HTTP::Request>
+This module provides functions that return newly created C<HTTP::Request>
 objects.  These functions are usually more convenient to use than the
-standard C<HTTP::Request> constructor for the most common requests.  The
-following functions are provided:
+standard C<HTTP::Request> constructor for the most common requests.
+
+Note that L<LWP::UserAgent> has several convenience methods, including
+C<get>, C<head>, C<delete>, C<post> and C<put>.
+
+The following functions are provided:
 
 =over 4
 
@@ -332,7 +340,7 @@ following functions are provided:
 
 =item GET $url, Header => Value,...
 
-The GET() function returns an C<HTTP::Request> object initialized with
+The C<GET> function returns an L<HTTP::Request> object initialized with
 the "GET" method and the specified URL.  It is roughly equivalent to the
 following call
 
@@ -344,11 +352,11 @@ following call
 but is less cluttered.  What is different is that a header named
 C<Content> will initialize the content part of the request instead of
 setting a header field.  Note that GET requests should normally not
-have a content, so this hack makes more sense for the PUT(), PATCH()
- and POST() functions described below.
+have a content, so this hack makes more sense for the C<PUT>, C<PATCH>
+ and C<POST> functions described below.
 
-The get(...) method of C<LWP::UserAgent> exists as a shortcut for
-$ua->request(GET ...).
+The C<get(...)> method of L<LWP::UserAgent> exists as a shortcut for
+C<< $ua->request(GET ...) >>.
 
 =item HEAD $url
 
@@ -356,37 +364,39 @@ $ua->request(GET ...).
 
 Like GET() but the method in the request is "HEAD".
 
-The head(...)  method of "LWP::UserAgent" exists as a shortcut for
-$ua->request(HEAD ...).
-
-=item PUT $url
-
-=item PUT $url, Header => Value,...
-
-=item PUT $url, Header => Value,..., Content => $content
-
-Like GET() but the method in the request is "PUT".
-
-The content of the request can be specified using the "Content"
-pseudo-header.  This steals a bit of the header field namespace as
-there is no way to directly specify a header that is actually called
-"Content".  If you really need this you must update the request
-returned in a separate statement.
-
-=item PATCH $url
-
-=item PATCH $url, Header => Value,...
-
-=item PATCH $url, Header => Value,..., Content => $content
-
-Like PUT() but the method in the request is "PATCH".
+The C<head(...)>  method of L<LWP::UserAgent> exists as a shortcut for
+C<< $ua->request(HEAD ...) >>.
 
 =item DELETE $url
 
 =item DELETE $url, Header => Value,...
 
-Like GET() but the method in the request is "DELETE".  This function
+Like C<GET> but the method in the request is C<DELETE>.  This function
 is not exported by default.
+
+=item PATCH $url
+
+=item PATCH $url, Header => Value,...
+
+=item PATCH $url, $form_ref, Header => Value,...
+
+=item PATCH $url, Header => Value,..., Content => $form_ref
+
+=item PATCH $url, Header => Value,..., Content => $content
+
+The same as C<POST> below, but the method in the request is C<PATCH>.
+
+=item PUT $url
+
+=item PUT $url, Header => Value,...
+
+=item PUT $url, $form_ref, Header => Value,...
+
+=item PUT $url, Header => Value,..., Content => $form_ref
+
+=item PUT $url, Header => Value,..., Content => $content
+
+The same as C<POST> below, but the method in the request is C<PUT>
 
 =item POST $url
 
@@ -398,13 +408,24 @@ is not exported by default.
 
 =item POST $url, Header => Value,..., Content => $content
 
-This works mostly like PUT() with "POST" as the method, but this
-function also takes a second optional array or hash reference
-parameter $form_ref.  As for PUT() the content can also be specified
-directly using the "Content" pseudo-header, and you may also provide
-the $form_ref this way.
+C<POST>, C<PATCH> and C<PUT> all work with the same parameters.
 
-The $form_ref argument can be used to pass key/value pairs for the
+  %data = ( title => 'something', body => something else' );
+  $ua = LWP::UserAgent->new();
+  $request = HTTP::Request::Common::POST( $url, [ %data ] );
+  $response = $ua->request($request);
+
+They take a second optional array or hash reference
+parameter C<$form_ref>.  The content can also be specified
+directly using the C<Content> pseudo-header, and you may also provide
+the C<$form_ref> this way.
+
+The C<Content> pseudo-header steals a bit of the header field namespace as
+there is no way to directly specify a header that is actually called
+"Content".  If you really need this you must update the request
+returned in a separate statement.
+
+The C<$form_ref> argument can be used to pass key/value pairs for the
 form content.  By default we will initialize a request using the
 C<application/x-www-form-urlencoded> content type.  This means that
 you can emulate an HTML E<lt>form> POSTing like this:
@@ -417,7 +438,7 @@ you can emulate an HTML E<lt>form> POSTing like this:
          perc   => '3%',
        ];
 
-This will create an HTTP::Request object that looks like this:
+This will create an L<HTTP::Request> object that looks like this:
 
   POST http://www.perl.org/survey.cgi
   Content-Length: 66
@@ -431,7 +452,7 @@ name or by passing the value as an array reference.
 The POST method also supports the C<multipart/form-data> content used
 for I<Form-based File Upload> as specified in RFC 1867.  You trigger
 this content format by specifying a content type of C<'form-data'> as
-one of the request headers.  If one of the values in the $form_ref is
+one of the request headers.  If one of the values in the C<$form_ref> is
 an array reference, then it is treated as a file part specification
 with the following interpretation:
 
@@ -449,7 +470,7 @@ want to suppress sending the filename when you provide a $file value.
 
 If a $file is provided by no C<Content-Type> header, then C<Content-Type>
 and C<Content-Encoding> will be filled in automatically with the values
-returned by LWP::MediaTypes::guess_media_type()
+returned by C<LWP::MediaTypes::guess_media_type()>
 
 Sending my F<~/.profile> to the survey used as example above can be
 achieved by this:
@@ -463,7 +484,7 @@ achieved by this:
                          init   => ["$ENV{HOME}/.profile"],
                        ]
 
-This will create an HTTP::Request object that almost looks this (the
+This will create an L<HTTP::Request> object that almost looks this (the
 boundary and the content of your F<~/.profile> is likely to be
 different):
 
@@ -496,26 +517,29 @@ different):
 
   --6G+f--
 
-If you set the $DYNAMIC_FILE_UPLOAD variable (exportable) to some TRUE
+If you set the C<$DYNAMIC_FILE_UPLOAD> variable (exportable) to some TRUE
 value, then you get back a request object with a subroutine closure as
 the content attribute.  This subroutine will read the content of any
 files on demand and return it in suitable chunks.  This allow you to
 upload arbitrary big files without using lots of memory.  You can even
 upload infinite files like F</dev/audio> if you wish; however, if
-the file is not a plain file, there will be no Content-Length header
+the file is not a plain file, there will be no C<Content-Length> header
 defined for the request.  Not all servers (or server
 applications) like this.  Also, if the file(s) change in size between
-the time the Content-Length is calculated and the time that the last
+the time the C<Content-Length> is calculated and the time that the last
 chunk is delivered, the subroutine will C<Croak>.
 
-The post(...)  method of "LWP::UserAgent" exists as a shortcut for
-$ua->request(POST ...).
+The C<post(...)>  method of L<LWP::UserAgent> exists as a shortcut for
+C<< $ua->request(POST ...) >>.
 
 =back
 
 =head1 SEE ALSO
 
 L<HTTP::Request>, L<LWP::UserAgent>
+
+Also, there are some examples in L<HTTP::Request/"EXAMPLES"> that you might
+find useful. For example, batch requests are explained there.
 
 =head1 AUTHOR
 
@@ -534,4 +558,3 @@ __END__
 
 
 #ABSTRACT: Construct common HTTP::Request objects
-

--- a/extlib/HTTP/Status.pm
+++ b/extlib/HTTP/Status.pm
@@ -1,7 +1,9 @@
 package HTTP::Status;
-$HTTP::Status::VERSION = '6.13';
+
 use strict;
 use warnings;
+
+our $VERSION = '6.14';
 
 require 5.002;   # because we use prototypes
 
@@ -18,6 +20,7 @@ my %StatusCode = (
     100 => 'Continue',
     101 => 'Switching Protocols',
     102 => 'Processing',                      # RFC 2518 (WebDAV)
+    103 => 'Early Hints',                     # RFC 8297
     200 => 'OK',
     201 => 'Created',
     202 => 'Accepted',
@@ -121,7 +124,7 @@ HTTP::Status - HTTP Status code processing
 
 =head1 VERSION
 
-version 6.13
+version 6.14
 
 =head1 SYNOPSIS
 
@@ -151,6 +154,7 @@ tag to import them all.
    HTTP_CONTINUE                        (100)
    HTTP_SWITCHING_PROTOCOLS             (101)
    HTTP_PROCESSING                      (102)
+   HTTP_EARLY_HINTS                     (103)
 
    HTTP_OK                              (200)
    HTTP_CREATED                         (201)

--- a/extlib/JSON.pm
+++ b/extlib/JSON.pm
@@ -9,7 +9,7 @@ BEGIN { @JSON::ISA = 'Exporter' }
 @JSON::EXPORT = qw(from_json to_json jsonToObj objToJson encode_json decode_json);
 
 BEGIN {
-    $JSON::VERSION = '2.96';
+    $JSON::VERSION = '2.97001';
     $JSON::DEBUG   = 0 unless (defined $JSON::DEBUG);
     $JSON::DEBUG   = $ENV{ PERL_JSON_DEBUG } if exists $ENV{ PERL_JSON_DEBUG };
 }
@@ -464,7 +464,7 @@ JSON - JSON (JavaScript Object Notation) encoder/decoder
 
 =head1 VERSION
 
-    2.96
+    2.97001
 
 =head1 DESCRIPTION
 

--- a/extlib/JSON/PP.pm
+++ b/extlib/JSON/PP.pm
@@ -14,7 +14,7 @@ use JSON::PP::Boolean;
 use Carp ();
 #use Devel::Peek;
 
-$JSON::PP::VERSION = '2.96';
+$JSON::PP::VERSION = '2.97001';
 
 @JSON::PP::EXPORT = qw(encode_json decode_json from_json to_json);
 
@@ -416,6 +416,8 @@ sub allow_bigint {
             return;
         } else {
             no warnings 'numeric';
+            # if the utf8 flag is on, it almost certainly started as a string
+            return if utf8::is_utf8($value);
             # detect numbers
             # string & "" -> ""
             # number & "" -> 0 (with warning)
@@ -1405,7 +1407,7 @@ BEGIN {
 $JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
 $JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
 
-sub is_bool { ref $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
+sub is_bool { blessed $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
 
 sub true  { $JSON::PP::true  }
 sub false { $JSON::PP::false }
@@ -1654,7 +1656,7 @@ JSON::PP - JSON::XS compatible pure-Perl module.
 
 =head1 VERSION
 
-    2.96
+    2.97001
 
 =head1 DESCRIPTION
 

--- a/extlib/JSON/PP/Boolean.pm
+++ b/extlib/JSON/PP/Boolean.pm
@@ -8,7 +8,7 @@ use overload (
     fallback => 1,
 );
 
-$JSON::PP::Boolean::VERSION = '2.96';
+$JSON::PP::Boolean::VERSION = '2.97001';
 
 1;
 

--- a/extlib/JSON/backportPP.pm
+++ b/extlib/JSON/backportPP.pm
@@ -15,7 +15,7 @@ use JSON::backportPP::Boolean;
 use Carp ();
 #use Devel::Peek;
 
-$JSON::backportPP::VERSION = '2.96';
+$JSON::backportPP::VERSION = '2.97001';
 
 @JSON::PP::EXPORT = qw(encode_json decode_json from_json to_json);
 
@@ -417,6 +417,8 @@ sub allow_bigint {
             return;
         } else {
             no warnings 'numeric';
+            # if the utf8 flag is on, it almost certainly started as a string
+            return if utf8::is_utf8($value);
             # detect numbers
             # string & "" -> ""
             # number & "" -> 0 (with warning)
@@ -1407,7 +1409,7 @@ BEGIN {
 $JSON::PP::true  = do { bless \(my $dummy = 1), "JSON::PP::Boolean" };
 $JSON::PP::false = do { bless \(my $dummy = 0), "JSON::PP::Boolean" };
 
-sub is_bool { ref $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
+sub is_bool { blessed $_[0] and $_[0]->isa("JSON::PP::Boolean"); }
 
 sub true  { $JSON::PP::true  }
 sub false { $JSON::PP::false }
@@ -1657,7 +1659,7 @@ JSON::PP - JSON::XS compatible pure-Perl module.
 
 =head1 VERSION
 
-    2.96
+    2.97001
 
 =head1 DESCRIPTION
 

--- a/extlib/JSON/backportPP/Boolean.pm
+++ b/extlib/JSON/backportPP/Boolean.pm
@@ -9,7 +9,7 @@ use overload (
     fallback => 1,
 );
 
-$JSON::backportPP::Boolean::VERSION = '2.96';
+$JSON::backportPP::Boolean::VERSION = '2.97001';
 
 1;
 

--- a/extlib/LWP.pm
+++ b/extlib/LWP.pm
@@ -1,6 +1,6 @@
 package LWP;
 
-our $VERSION = '6.26';
+our $VERSION = '6.31';
 
 require LWP::UserAgent;  # this should load everything you need
 

--- a/extlib/LWP/Authen/Basic.pm
+++ b/extlib/LWP/Authen/Basic.pm
@@ -1,6 +1,8 @@
 package LWP::Authen::Basic;
-$LWP::Authen::Basic::VERSION = '6.26';
+
 use strict;
+
+our $VERSION = '6.31';
 
 require MIME::Base64;
 

--- a/extlib/LWP/Authen/Digest.pm
+++ b/extlib/LWP/Authen/Digest.pm
@@ -1,7 +1,9 @@
 package LWP::Authen::Digest;
-$LWP::Authen::Digest::VERSION = '6.26';
+
 use strict;
 use base 'LWP::Authen::Basic';
+
+our $VERSION = '6.31';
 
 require Digest::MD5;
 

--- a/extlib/LWP/Authen/Ntlm.pm
+++ b/extlib/LWP/Authen/Ntlm.pm
@@ -2,7 +2,7 @@ package LWP::Authen::Ntlm;
 
 use strict;
 
-our $VERSION = '6.26';
+our $VERSION = '6.31';
 
 use Authen::NTLM "1.02";
 use MIME::Base64 "2.12";

--- a/extlib/LWP/ConnCache.pm
+++ b/extlib/LWP/ConnCache.pm
@@ -2,7 +2,7 @@ package LWP::ConnCache;
 
 use strict;
 
-our $VERSION = '6.26';
+our $VERSION = '6.31';
 our $DEBUG;
 
 sub new {

--- a/extlib/LWP/Debug.pm
+++ b/extlib/LWP/Debug.pm
@@ -1,5 +1,7 @@
 package LWP::Debug;    # legacy
-$LWP::Debug::VERSION = '6.26';
+
+our $VERSION = '6.31';
+
 require Exporter;
 our @ISA       = qw(Exporter);
 our @EXPORT_OK = qw(level trace debug conns);

--- a/extlib/LWP/Debug/TraceHTTP.pm
+++ b/extlib/LWP/Debug/TraceHTTP.pm
@@ -1,5 +1,5 @@
 package LWP::Debug::TraceHTTP;
-$LWP::Debug::TraceHTTP::VERSION = '6.26';
+
 # Just call:
 #
 #   require LWP::Debug::TraceHTTP;
@@ -11,8 +11,11 @@ $LWP::Debug::TraceHTTP::VERSION = '6.26';
 use strict;
 use base 'LWP::Protocol::http';
 
-package LWP::Debug::TraceHTTP::Socket;
-$LWP::Debug::TraceHTTP::Socket::VERSION = '6.26';
+our $VERSION = '6.31';
+
+package # hide from PAUSE
+    LWP::Debug::TraceHTTP::Socket;
+
 use Data::Dump 1.13;
 use Data::Dump::Trace qw(autowrap mcall);
 

--- a/extlib/LWP/DebugFile.pm
+++ b/extlib/LWP/DebugFile.pm
@@ -1,5 +1,7 @@
 package LWP::DebugFile;
-$LWP::DebugFile::VERSION = '6.26';
+
+our $VERSION = '6.31';
+
 # legacy stub
 
 1;

--- a/extlib/LWP/MemberMixin.pm
+++ b/extlib/LWP/MemberMixin.pm
@@ -1,5 +1,7 @@
 package LWP::MemberMixin;
-$LWP::MemberMixin::VERSION = '6.26';
+
+our $VERSION = '6.31';
+
 sub _elem {
     my $self = shift;
     my $elem = shift;

--- a/extlib/LWP/Protocol.pm
+++ b/extlib/LWP/Protocol.pm
@@ -2,7 +2,7 @@ package LWP::Protocol;
 
 use base 'LWP::MemberMixin';
 
-our $VERSION = '6.26';
+our $VERSION = '6.31';
 
 use strict;
 use Carp ();
@@ -53,7 +53,7 @@ sub implementor
 
     return '' unless $scheme =~ /^([.+\-\w]+)$/;  # check valid URL schemes
     $scheme = $1; # untaint
-    $scheme =~ s/[.+\-]/_/g;  # make it a legal module name
+    $scheme =~ tr/.+-/_/;  # make it a legal module name
 
     # scheme not yet known, look for a 'use'd implementation
     $ic = "LWP::Protocol::$scheme";  # default location

--- a/extlib/LWP/Protocol/cpan.pm
+++ b/extlib/LWP/Protocol/cpan.pm
@@ -1,8 +1,10 @@
 package LWP::Protocol::cpan;
-$LWP::Protocol::cpan::VERSION = '6.26';
+
 use strict;
 
 use base qw(LWP::Protocol);
+
+our $VERSION = '6.31';
 
 require URI;
 require HTTP::Status;

--- a/extlib/LWP/Protocol/data.pm
+++ b/extlib/LWP/Protocol/data.pm
@@ -1,8 +1,10 @@
 package LWP::Protocol::data;
-$LWP::Protocol::data::VERSION = '6.26';
+
 # Implements access to data:-URLs as specified in RFC 2397
 
 use strict;
+
+our $VERSION = '6.31';
 
 require HTTP::Response;
 require HTTP::Status;

--- a/extlib/LWP/Protocol/file.pm
+++ b/extlib/LWP/Protocol/file.pm
@@ -1,8 +1,10 @@
 package LWP::Protocol::file;
-$LWP::Protocol::file::VERSION = '6.26';
+
 use base qw(LWP::Protocol);
 
 use strict;
+
+our $VERSION = '6.31';
 
 require LWP::MediaTypes;
 require HTTP::Request;
@@ -126,17 +128,17 @@ sub request
 
     # read the file
     if ($method ne "HEAD") {
-	open(F, $path) or return new
+	open(my $fh, '<', $path) or return new
 	    HTTP::Response(HTTP::Status::RC_INTERNAL_SERVER_ERROR,
 			   "Cannot read file '$path': $!");
-	binmode(F);
+	binmode($fh);
 	$response =  $self->collect($arg, $response, sub {
 	    my $content = "";
-	    my $bytes = sysread(F, $content, $size);
+	    my $bytes = sysread($fh, $content, $size);
 	    return \$content if $bytes > 0;
 	    return \ "";
 	});
-	close(F);
+	close($fh);
     }
 
     $response;

--- a/extlib/LWP/Protocol/ftp.pm
+++ b/extlib/LWP/Protocol/ftp.pm
@@ -1,9 +1,11 @@
 package LWP::Protocol::ftp;
-$LWP::Protocol::ftp::VERSION = '6.26';
+
 # Implementation of the ftp protocol (RFC 959). We let the Net::FTP
 # package do all the dirty work.
 use base qw(LWP::Protocol);
 use strict;
+
+our $VERSION = '6.31';
 
 use Carp            ();
 use HTTP::Status    ();
@@ -15,9 +17,10 @@ use File::Listing   ();
 
 {
 
-    package LWP::Protocol::MyFTP;
-$LWP::Protocol::MyFTP::VERSION = '6.26';
-use strict;
+    package # hide from PAUSE
+        LWP::Protocol::MyFTP;
+
+    use strict;
     use base qw(Net::FTP);
 
     sub new {

--- a/extlib/LWP/Protocol/gopher.pm
+++ b/extlib/LWP/Protocol/gopher.pm
@@ -1,5 +1,5 @@
 package LWP::Protocol::gopher;
-$LWP::Protocol::gopher::VERSION = '6.26';
+
 # Implementation of the gopher protocol (RFC 1436)
 #
 # This code is based on 'wwwgopher.pl,v 0.10 1994/10/17 18:12:34 shelden'
@@ -8,6 +8,8 @@ $LWP::Protocol::gopher::VERSION = '6.26';
 # including contributions from Marc van Heyningen and Martijn Koster.
 
 use strict;
+
+our $VERSION = '6.31';
 
 require HTTP::Response;
 require HTTP::Status;
@@ -185,7 +187,7 @@ sub gopher2url
 sub menu2html {
     my($menu) = @_;
 
-    $menu =~ s/\015//g;  # remove carriage return
+    $menu =~ tr/\015//d;  # remove carriage return
     my $tmp = <<"EOT";
 <HTML>
 <HEAD>

--- a/extlib/LWP/Protocol/http.pm
+++ b/extlib/LWP/Protocol/http.pm
@@ -1,6 +1,8 @@
 package LWP::Protocol::http;
-$LWP::Protocol::http::VERSION = '6.26';
+
 use strict;
+
+our $VERSION = '6.31';
 
 require HTTP::Response;
 require HTTP::Status;
@@ -42,6 +44,8 @@ sub _new_socket
 	    $@ =~ /\b(Crypt-SSLeay can't verify hostnames)\b/
 	) {
 	    $status .= " ($1)";
+	} elsif ($@) {
+	    $status .= " ($@)";
 	}
 	die "$status\n\n$@";
     }
@@ -232,7 +236,7 @@ sub request
     $request_headers->scan(sub {
 			       my($k, $v) = @_;
 			       $k =~ s/^://;
-			       $v =~ s/\n/ /g;
+			       $v =~ tr/\n/ /;
 			       push(@h, $k, $v);
 			   });
 
@@ -497,8 +501,9 @@ sub request
 
 
 #-----------------------------------------------------------
-package LWP::Protocol::http::SocketMethods;
-$LWP::Protocol::http::SocketMethods::VERSION = '6.26';
+package # hide from PAUSE
+    LWP::Protocol::http::SocketMethods;
+
 sub ping {
     my $self = shift;
     !$self->can_read(0);
@@ -510,8 +515,9 @@ sub increment_response_count {
 }
 
 #-----------------------------------------------------------
-package LWP::Protocol::http::Socket;
-$LWP::Protocol::http::Socket::VERSION = '6.26';
-use base qw(LWP::Protocol::http::SocketMethods Net::HTTP);
+package # hide from PAUSE
+    LWP::Protocol::http::Socket;
+
+use parent -norequire, qw(LWP::Protocol::http::SocketMethods Net::HTTP);
 
 1;

--- a/extlib/LWP/Protocol/loopback.pm
+++ b/extlib/LWP/Protocol/loopback.pm
@@ -1,6 +1,9 @@
 package LWP::Protocol::loopback;
-$LWP::Protocol::loopback::VERSION = '6.26';
+
 use strict;
+
+our $VERSION = '6.31';
+
 require HTTP::Response;
 
 use base qw(LWP::Protocol);

--- a/extlib/LWP/Protocol/mailto.pm
+++ b/extlib/LWP/Protocol/mailto.pm
@@ -1,5 +1,5 @@
 package LWP::Protocol::mailto;
-$LWP::Protocol::mailto::VERSION = '6.26';
+
 # This module implements the mailto protocol.  It is just a simple
 # frontend to the Unix sendmail program except on MacOS, where it uses
 # Mail::Internet.
@@ -10,6 +10,8 @@ require HTTP::Status;
 
 use Carp;
 use strict;
+
+our $VERSION = '6.31';
 
 use base qw(LWP::Protocol);
 our $SENDMAIL;

--- a/extlib/LWP/Protocol/nntp.pm
+++ b/extlib/LWP/Protocol/nntp.pm
@@ -1,8 +1,10 @@
 package LWP::Protocol::nntp;
-$LWP::Protocol::nntp::VERSION = '6.26';
+
 # Implementation of the Network News Transfer Protocol (RFC 977)
 
 use base qw(LWP::Protocol);
+
+our $VERSION = '6.31';
 
 require HTTP::Response;
 require HTTP::Status;

--- a/extlib/LWP/Protocol/nogo.pm
+++ b/extlib/LWP/Protocol/nogo.pm
@@ -4,8 +4,10 @@ package LWP::Protocol::nogo;
 #   LWP::Protocol::implementor(that_scheme, 'LWP::Protocol::nogo');
 # For then on, attempts to access URLs with that scheme will generate
 # a 500 error.
-$LWP::Protocol::nogo::VERSION = '6.26';
+
 use strict;
+
+our $VERSION = '6.31';
 
 require HTTP::Response;
 require HTTP::Status;

--- a/extlib/LWP/RobotUA.pm
+++ b/extlib/LWP/RobotUA.pm
@@ -2,7 +2,7 @@ package LWP::RobotUA;
 
 use base qw(LWP::UserAgent);
 
-our $VERSION = '6.26';
+our $VERSION = '6.31';
 
 require WWW::RobotRules;
 require HTTP::Request;

--- a/extlib/LWP/Simple.pm
+++ b/extlib/LWP/Simple.pm
@@ -2,7 +2,7 @@ package LWP::Simple;
 
 use strict;
 
-our $VERSION = '6.26';
+our $VERSION = '6.31';
 
 require Exporter;
 

--- a/extlib/Try/Tiny.pm
+++ b/extlib/Try/Tiny.pm
@@ -1,8 +1,8 @@
-package Try::Tiny; # git description: v0.27-8-g8dc27c7
+package Try::Tiny; # git description: v0.29-2-g3b23a06
 use 5.006;
 # ABSTRACT: Minimal try/catch with proper preservation of $@
 
-our $VERSION = '0.28';
+our $VERSION = '0.30';
 
 use strict;
 use warnings;
@@ -70,8 +70,7 @@ sub try (&;@) {
   # $catch->();
 
   # name the blocks if we have Sub::Name installed
-  my $caller = caller;
-  _subname("${caller}::try {...} " => $try)
+  _subname(caller().'::try {...} ' => $try)
     if _HAS_SUBNAME;
 
   # set up scope guards to invoke the finally blocks at the end.
@@ -140,8 +139,7 @@ sub catch (&;@) {
 
   croak 'Useless bare catch()' unless wantarray;
 
-  my $caller = caller;
-  _subname("${caller}::catch {...} " => $block)
+  _subname(caller().'::catch {...} ' => $block)
     if _HAS_SUBNAME;
   return (
     bless(\$block, 'Try::Tiny::Catch'),
@@ -154,8 +152,7 @@ sub finally (&;@) {
 
   croak 'Useless bare finally()' unless wantarray;
 
-  my $caller = caller;
-  _subname("${caller}::finally {...} " => $block)
+  _subname(caller().'::finally {...} ' => $block)
     if _HAS_SUBNAME;
   return (
     bless(\$block, 'Try::Tiny::Finally'),
@@ -208,7 +205,7 @@ Try::Tiny - Minimal try/catch with proper preservation of $@
 
 =head1 VERSION
 
-version 0.28
+version 0.30
 
 =head1 SYNOPSIS
 
@@ -399,8 +396,10 @@ not yet handled.
 C<$@> must be properly localized before invoking C<eval> in order to avoid this
 issue.
 
-More specifically, C<$@> is clobbered at the beginning of the C<eval>, which
-also makes it impossible to capture the previous error before you die (for
+More specifically,
+L<before Perl version 5.14.0|perl5140delta/"Exception Handling">
+C<$@> was clobbered at the beginning of the C<eval>, which
+also made it impossible to capture the previous error before you die (for
 instance when making exception objects with error stacks).
 
 For this reason C<try> will actually set C<$@> to its previous value (the one
@@ -443,7 +442,7 @@ because due to the previous caveats it may have been unset.
 C<$@> could also be an overloaded error object that evaluates to false, but
 that's asking for trouble anyway.
 
-The classic failure mode is:
+The classic failure mode (fixed in L<Perl 5.14.0|perl5140delta/"Exception Handling">) is:
 
   sub Object::DESTROY {
     eval { ... }
@@ -479,9 +478,11 @@ be sure the C<eval> was aborted due to an error:
 This is because an C<eval> that caught a C<die> will always return a false
 value.
 
-=head1 SHINY SYNTAX
+=head1 ALTERNATE SYNTAX
 
-Using Perl 5.10 you can use L<perlsyn/"Switch statements">.
+Using Perl 5.10 you can use L<perlsyn/"Switch statements"> (but please don't,
+because that syntax has since been deprecated because there was too much
+unexpected magical behaviour).
 
 =for stopwords topicalizer
 
@@ -626,8 +627,8 @@ confusing behavior:
     }
   }
 
-Note that this behavior was changed once again in L<Perl5 version 18
-|https://metacpan.org/module/perldelta#given-now-aliases-the-global-_>.
+Note that this behavior was changed once again in
+L<Perl5 version 18|https://metacpan.org/module/perldelta#given-now-aliases-the-global-_>.
 However, since the entirety of lexical C<$_> is now L<considered experimental
 |https://metacpan.org/module/perldelta#Lexical-_-is-now-experimental>, it
 is unclear whether the new version 18 behavior is final.
@@ -699,7 +700,7 @@ Jesse Luehrs <doy@tozt.net>
 
 =head1 CONTRIBUTORS
 
-=for stopwords Karen Etheridge Peter Rabbitson Ricardo Signes Mark Fowler Graham Knop Lukas Mai Dagfinn Ilmari Mannsåker Paul Howarth Rudolf Leermakers anaxagoras awalker chromatic Alex cm-perl Andrew Yates David Lowe Glenn Hans Dieter Pearcey Jonathan Yu Marc Mims Stosberg Pali
+=for stopwords Karen Etheridge Peter Rabbitson Ricardo Signes Mark Fowler Graham Knop Lukas Mai Aristotle Pagaltzis Dagfinn Ilmari Mannsåker Paul Howarth Rudolf Leermakers anaxagoras awalker chromatic Alex cm-perl Andrew Yates David Lowe Glenn Hans Dieter Pearcey Jens Berthold Jonathan Yu Marc Mims Stosberg Pali
 
 =over 4
 
@@ -726,6 +727,10 @@ Graham Knop <haarg@haarg.org>
 =item *
 
 Lukas Mai <l.mai@web.de>
+
+=item *
+
+Aristotle Pagaltzis <pagaltzis@gmx.de>
 
 =item *
 
@@ -774,6 +779,10 @@ Glenn Fowler <cebjyre@cpan.org>
 =item *
 
 Hans Dieter Pearcey <hdp@weftsoar.net>
+
+=item *
+
+Jens Berthold <jens@jebecs.de>
 
 =item *
 

--- a/extlib/URI.pm
+++ b/extlib/URI.pm
@@ -3,7 +3,7 @@ package URI;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 our ($ABS_REMOTE_LEADING_DOTS, $ABS_ALLOW_RELATIVE_SCHEME, $DEFAULT_QUERY_FORM_DELIMITER);
@@ -357,6 +357,8 @@ __END__
 URI - Uniform Resource Identifiers (absolute and relative)
 
 =head1 SYNOPSIS
+
+ use URI;
 
  $u1 = URI->new("http://www.perl.com");
  $u2 = URI->new("foo", "http");

--- a/extlib/URI/IRI.pm
+++ b/extlib/URI/IRI.pm
@@ -8,7 +8,7 @@ use URI ();
 
 use overload '""' => sub { shift->as_string };
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub new {

--- a/extlib/URI/QueryParam.pm
+++ b/extlib/URI/QueryParam.pm
@@ -3,7 +3,7 @@ package URI::QueryParam;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub URI::_query::query_param {

--- a/extlib/URI/Split.pm
+++ b/extlib/URI/Split.pm
@@ -3,7 +3,7 @@ package URI::Split;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use Exporter 5.57 'import';

--- a/extlib/URI/_foreign.pm
+++ b/extlib/URI/_foreign.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'URI::_generic';
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 1;

--- a/extlib/URI/_generic.pm
+++ b/extlib/URI/_generic.pm
@@ -8,7 +8,7 @@ use parent qw(URI URI::_query);
 use URI::Escape qw(uri_unescape);
 use Carp ();
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 my $ACHAR = $URI::uric;  $ACHAR =~ s,\\[/?],,g;

--- a/extlib/URI/_idna.pm
+++ b/extlib/URI/_idna.pm
@@ -9,7 +9,7 @@ use warnings;
 use URI::_punycode qw(encode_punycode decode_punycode);
 use Carp qw(croak);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 BEGIN {

--- a/extlib/URI/_ldap.pm
+++ b/extlib/URI/_ldap.pm
@@ -7,7 +7,7 @@ package URI::_ldap;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use URI::Escape qw(uri_unescape);

--- a/extlib/URI/_login.pm
+++ b/extlib/URI/_login.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent qw(URI::_server URI::_userpass);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 # Generic terminal logins.  This is used as a base class for 'telnet',

--- a/extlib/URI/_punycode.pm
+++ b/extlib/URI/_punycode.pm
@@ -3,7 +3,7 @@ package URI::_punycode;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use Exporter 'import';
@@ -147,58 +147,72 @@ sub min {
 1;
 __END__
 
+=encoding utf8
+
 =head1 NAME
 
 URI::_punycode - encodes Unicode string in Punycode
 
 =head1 SYNOPSIS
 
-  use URI::_punycode;
-  $punycode = encode_punycode($unicode);
-  $unicode  = decode_punycode($punycode);
+  use strict;
+  use warnings;
+  use utf8;
+
+  use URI::_punycode qw(encode_punycode decode_punycode);
+
+  # encode a unicode string
+  my $punycode = encode_punycode('http://☃.net'); # http://.net-xc8g
+  $punycode = encode_punycode('bücher'); # bcher-kva
+  $punycode = encode_punycode('他们为什么不说中文'); # ihqwcrb4cv8a8dqg056pqjye
+
+  # decode a punycode string back into a unicode string
+  my $unicode = decode_punycode('http://.net-xc8g'); # http://☃.net
+  $unicode = decode_punycode('bcher-kva'); # bücher
+  $unicode = decode_punycode('ihqwcrb4cv8a8dqg056pqjye'); # 他们为什么不说中文
 
 =head1 DESCRIPTION
 
-URI::_punycode is a module to encode / decode Unicode strings into
-Punycode, an efficient encoding of Unicode for use with IDNA.
-
-This module requires Perl 5.6.0 or over to handle UTF8 flagged Unicode
-strings.
+L<URI::_punycode> is a module to encode / decode Unicode strings into
+L<Punycode|https://tools.ietf.org/html/rfc3492>, an efficient
+encoding of Unicode for use with L<IDNA|https://tools.ietf.org/html/rfc5890>.
 
 =head1 FUNCTIONS
 
-This module exports following functions by default.
+All functions throw exceptions on failure. You can C<catch> them with
+L<Syntax::Keyword::Try> or L<Try::Tiny>. The following functions are exported
+by default.
 
-=over 4
+=head2 encode_punycode
 
-=item encode_punycode
+  my $punycode = encode_punycode('http://☃.net');  # http://.net-xc8g
+  $punycode = encode_punycode('bücher'); # bcher-kva
+  $punycode = encode_punycode('他们为什么不说中文') # ihqwcrb4cv8a8dqg056pqjye
 
-  $punycode = encode_punycode($unicode);
-
-takes Unicode string (UTF8-flagged variable) and returns Punycode
+Takes a Unicode string (UTF8-flagged variable) and returns a Punycode
 encoding for it.
 
-=item decode_punycode
+=head2 decode_punycode
 
-  $unicode = decode_punycode($punycode)
+  my $unicode = decode_punycode('http://.net-xc8g'); # http://☃.net
+  $unicode = decode_punycode('bcher-kva'); # bücher
+  $unicode = decode_punycode('ihqwcrb4cv8a8dqg056pqjye'); # 他们为什么不说中文
 
-takes Punycode encoding and returns original Unicode string.
-
-=back
-
-These functions throw exceptions on failure. You can catch 'em via
-C<eval>.
+Takes a Punycode encoding and returns original Unicode string.
 
 =head1 AUTHOR
 
-Tatsuhiko Miyagawa E<lt>miyagawa@bulknews.netE<gt> is the author of
-IDNA::Punycode v0.02 which was the basis for this module.
-
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself.
+Tatsuhiko Miyagawa <F<miyagawa@bulknews.net>> is the author of
+L<IDNA::Punycode> which was the basis for this module.
 
 =head1 SEE ALSO
 
-L<IDNA::Punycode>, RFC 3492
+L<IDNA::Punycode>, L<RFC 3492|https://tools.ietf.org/html/rfc3492>,
+L<RFC 5891|https://tools.ietf.org/html/rfc5891>
+
+=head1 COPYRIGHT AND LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
 
 =cut

--- a/extlib/URI/_query.pm
+++ b/extlib/URI/_query.pm
@@ -6,7 +6,7 @@ use warnings;
 use URI ();
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub query

--- a/extlib/URI/_segment.pm
+++ b/extlib/URI/_segment.pm
@@ -11,7 +11,7 @@ use URI::Escape qw(uri_unescape);
 use overload '""' => sub { $_[0]->[0] },
              fallback => 1;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub new

--- a/extlib/URI/_server.pm
+++ b/extlib/URI/_server.pm
@@ -7,7 +7,7 @@ use parent 'URI::_generic';
 
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub _uric_escape {

--- a/extlib/URI/_userpass.pm
+++ b/extlib/URI/_userpass.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub user

--- a/extlib/URI/data.pm
+++ b/extlib/URI/data.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'URI';
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use MIME::Base64 qw(encode_base64 decode_base64);

--- a/extlib/URI/file/Base.pm
+++ b/extlib/URI/file/Base.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use URI::Escape qw();
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub new

--- a/extlib/URI/file/FAT.pm
+++ b/extlib/URI/file/FAT.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'URI::file::Win32';
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub fix_path

--- a/extlib/URI/file/Mac.pm
+++ b/extlib/URI/file/Mac.pm
@@ -7,7 +7,7 @@ use parent 'URI::file::Base';
 
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub _file_extract_path

--- a/extlib/URI/file/OS2.pm
+++ b/extlib/URI/file/OS2.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'URI::file::Win32';
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 # The Win32 version translates k:/foo to file://k:/foo  (?!)

--- a/extlib/URI/file/QNX.pm
+++ b/extlib/URI/file/QNX.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'URI::file::Unix';
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub _file_extract_path

--- a/extlib/URI/file/Unix.pm
+++ b/extlib/URI/file/Unix.pm
@@ -7,7 +7,7 @@ use parent 'URI::file::Base';
 
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub _file_extract_path

--- a/extlib/URI/file/Win32.pm
+++ b/extlib/URI/file/Win32.pm
@@ -7,7 +7,7 @@ use parent 'URI::file::Base';
 
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub _file_extract_authority

--- a/extlib/URI/ftp.pm
+++ b/extlib/URI/ftp.pm
@@ -3,7 +3,7 @@ package URI::ftp;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent qw(URI::_server URI::_userpass);

--- a/extlib/URI/gopher.pm
+++ b/extlib/URI/gopher.pm
@@ -3,7 +3,7 @@ package URI::gopher;  # <draft-murali-url-gopher>, Dec 4, 1996
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_server';

--- a/extlib/URI/http.pm
+++ b/extlib/URI/http.pm
@@ -3,7 +3,7 @@ package URI::http;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_server';

--- a/extlib/URI/https.pm
+++ b/extlib/URI/https.pm
@@ -3,7 +3,7 @@ package URI::https;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::http';

--- a/extlib/URI/ldap.pm
+++ b/extlib/URI/ldap.pm
@@ -7,7 +7,7 @@ package URI::ldap;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent qw(URI::_ldap URI::_server);

--- a/extlib/URI/ldapi.pm
+++ b/extlib/URI/ldapi.pm
@@ -3,7 +3,7 @@ package URI::ldapi;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent qw(URI::_ldap URI::_generic);

--- a/extlib/URI/ldaps.pm
+++ b/extlib/URI/ldaps.pm
@@ -3,7 +3,7 @@ package URI::ldaps;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::ldap';

--- a/extlib/URI/mailto.pm
+++ b/extlib/URI/mailto.pm
@@ -3,7 +3,7 @@ package URI::mailto;  # RFC 2368
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent qw(URI URI::_query);

--- a/extlib/URI/mms.pm
+++ b/extlib/URI/mms.pm
@@ -3,7 +3,7 @@ package URI::mms;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::http';

--- a/extlib/URI/news.pm
+++ b/extlib/URI/news.pm
@@ -3,7 +3,7 @@ package URI::news;  # draft-gilman-news-url-01
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_server';

--- a/extlib/URI/nntp.pm
+++ b/extlib/URI/nntp.pm
@@ -3,7 +3,7 @@ package URI::nntp;  # draft-gilman-news-url-01
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::news';

--- a/extlib/URI/pop.pm
+++ b/extlib/URI/pop.pm
@@ -3,7 +3,7 @@ package URI::pop;   # RFC 2384
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_server';

--- a/extlib/URI/rlogin.pm
+++ b/extlib/URI/rlogin.pm
@@ -3,7 +3,7 @@ package URI::rlogin;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_login';

--- a/extlib/URI/rsync.pm
+++ b/extlib/URI/rsync.pm
@@ -5,7 +5,7 @@ package URI::rsync;  # http://rsync.samba.org/
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent qw(URI::_server URI::_userpass);

--- a/extlib/URI/rtsp.pm
+++ b/extlib/URI/rtsp.pm
@@ -3,7 +3,7 @@ package URI::rtsp;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::http';

--- a/extlib/URI/rtspu.pm
+++ b/extlib/URI/rtspu.pm
@@ -3,7 +3,7 @@ package URI::rtspu;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::rtsp';

--- a/extlib/URI/sftp.pm
+++ b/extlib/URI/sftp.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use parent 'URI::ssh';
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 1;

--- a/extlib/URI/sip.pm
+++ b/extlib/URI/sip.pm
@@ -14,7 +14,7 @@ use parent qw(URI::_server URI::_userpass);
 
 use URI::Escape qw(uri_unescape);
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 sub default_port { 5060 }

--- a/extlib/URI/sips.pm
+++ b/extlib/URI/sips.pm
@@ -3,7 +3,7 @@ package URI::sips;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::sip';

--- a/extlib/URI/snews.pm
+++ b/extlib/URI/snews.pm
@@ -3,7 +3,7 @@ package URI::snews;  # draft-gilman-news-url-01
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::news';

--- a/extlib/URI/ssh.pm
+++ b/extlib/URI/ssh.pm
@@ -3,7 +3,7 @@ package URI::ssh;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_login';

--- a/extlib/URI/telnet.pm
+++ b/extlib/URI/telnet.pm
@@ -3,7 +3,7 @@ package URI::telnet;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_login';

--- a/extlib/URI/tn3270.pm
+++ b/extlib/URI/tn3270.pm
@@ -3,7 +3,7 @@ package URI::tn3270;
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::_login';

--- a/extlib/URI/urn.pm
+++ b/extlib/URI/urn.pm
@@ -3,7 +3,7 @@ package URI::urn;  # RFC 2141
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI';

--- a/extlib/URI/urn/isbn.pm
+++ b/extlib/URI/urn/isbn.pm
@@ -3,7 +3,7 @@ package URI::urn::isbn;  # RFC 3187
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 
 use parent 'URI::urn';
 

--- a/extlib/URI/urn/oid.pm
+++ b/extlib/URI/urn/oid.pm
@@ -3,7 +3,7 @@ package URI::urn::oid;  # RFC 2061
 use strict;
 use warnings;
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 $VERSION = eval $VERSION;
 
 use parent 'URI::urn';

--- a/extlib/XML/XPath/Step.pm
+++ b/extlib/XML/XPath/Step.pm
@@ -1,16 +1,17 @@
-# $Id: Step.pm 4532 2004-05-11 05:15:40Z ezra $
-
 package XML::XPath::Step;
+
+$VERSION = '1.42';
+
 use XML::XPath::Parser;
 use XML::XPath::Node;
-use strict;
+use strict; use warnings;
 
 # the beginnings of using XS for this file...
 # require DynaLoader;
 # use vars qw/$VERSION @ISA/;
 # $VERSION = '1.0';
 # @ISA = qw(DynaLoader);
-# 
+#
 # bootstrap XML::XPath::Step $VERSION;
 
 sub test_qname () { 0; } # Full name
@@ -47,7 +48,7 @@ sub as_string {
     my $string = $self->{axis} . "::";
 
     my $test = $self->{test};
-        
+
     if ($test == test_nt_pi) {
         $string .= 'processing-instruction(';
         if ($self->{literal}->value) {
@@ -70,7 +71,7 @@ sub as_string {
     else {
         $string .= $self->{literal};
     }
-    
+
     foreach (@{$self->{predicates}}) {
         next unless defined $_;
         $string .= "[" . $_->as_string . "]";
@@ -83,9 +84,9 @@ sub as_xml {
     my $string = "<Step>\n";
     $string .= "<Axis>" . $self->{axis} . "</Axis>\n";
     my $test = $self->{test};
-    
+
     $string .= "<Test>";
-    
+
     if ($test == test_nt_pi) {
         $string .= '<processing-instruction';
         if ($self->{literal}->value) {
@@ -112,47 +113,50 @@ sub as_xml {
     else {
         $string .= '<nametest>' . $self->{literal} . '</nametest>';
     }
-    
+
     $string .= "</Test>\n";
-    
+
     foreach (@{$self->{predicates}}) {
         next unless defined $_;
         $string .= "<Predicate>\n" . $_->as_xml() . "</Predicate>\n";
     }
-    
+
     $string .= "</Step>\n";
-    
+
     return $string;
 }
 
 sub evaluate {
     my $self = shift;
     my $from = shift; # context nodeset
-    
+
 #    warn "Step::evaluate called with ", $from->size, " length nodeset\n";
-    
+    my $saved_context = $self->{pp}->get_context_set;
+    my $saved_pos = $self->{pp}->get_context_pos;
+
     $self->{pp}->set_context_set($from);
-    
+
     my $initial_nodeset = XML::XPath::NodeSet->new();
-    
+
     # See spec section 2.1, paragraphs 3,4,5:
     # The node-set selected by the location step is the node-set
     # that results from generating an initial node set from the
     # axis and node-test, and then filtering that node-set by
     # each of the predicates in turn.
-    
+
     # Make each node in the nodeset be the context node, one by one
     for(my $i = 1; $i <= $from->size; $i++) {
         $self->{pp}->set_context_pos($i);
         $initial_nodeset->append($self->evaluate_node($from->get_node($i)));
     }
-    
+
 #    warn "Step::evaluate initial nodeset size: ", $initial_nodeset->size, "\n";
-    
-    $self->{pp}->set_context_set(undef);
+
+    $self->{pp}->set_context_set($saved_context);
+    $self->{pp}->set_context_pos($saved_pos);
 
     $initial_nodeset->sort;
-        
+
     return $initial_nodeset;
 }
 
@@ -160,13 +164,13 @@ sub evaluate {
 sub evaluate_node {
     my $self = shift;
     my $context = shift;
-    
+
 #    warn "Evaluate node: $self->{axis}\n";
-    
+
 #    warn "Node: ", $context->[node_name], "\n";
-    
+
     my $method = $self->{axis_method};
-    
+
     my $results = XML::XPath::NodeSet->new();
     no strict 'refs';
     eval {
@@ -175,22 +179,22 @@ sub evaluate_node {
     if ($@) {
         die "axis $method not implemented [$@]\n";
     }
-    
+
 #    warn("results: ", join('><', map {$_->string_value} @$results), "\n");
     # filter initial nodeset by each predicate
     foreach my $predicate (@{$self->{predicates}}) {
         $results = $self->filter_by_predicate($results, $predicate);
     }
-    
+
     return $results;
 }
 
 sub axis_ancestor {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     my $parent = $context->getParentNode;
-        
+
     START:
     return $results unless $parent;
     if (node_test($self, $parent)) {
@@ -203,7 +207,7 @@ sub axis_ancestor {
 sub axis_ancestor_or_self {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     START:
     return $results unless $context;
     if (node_test($self, $context)) {
@@ -216,7 +220,7 @@ sub axis_ancestor_or_self {
 sub axis_attribute {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     foreach my $attrib (@{$context->getAttributes}) {
         if ($self->test_attribute($attrib)) {
             $results->push($attrib);
@@ -227,7 +231,7 @@ sub axis_attribute {
 sub axis_child {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     foreach my $node (@{$context->getChildNodes}) {
         if (node_test($self, $node)) {
             $results->push($node);
@@ -253,9 +257,9 @@ sub axis_descendant {
 sub axis_descendant_or_self {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     my @stack = ($context);
-    
+
     while (@stack) {
         my $node = pop @stack;
         if (node_test($self, $node)) {
@@ -268,12 +272,12 @@ sub axis_descendant_or_self {
 sub axis_following {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     START:
 
     my $parent = $context->getParentNode;
     return $results unless $parent;
-        
+
     while ($context = $context->getNextSibling) {
         axis_descendant_or_self($self, $context, $results);
     }
@@ -296,7 +300,7 @@ sub axis_following_sibling {
 sub axis_namespace {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     return $results unless $context->isElementNode;
     foreach my $ns (@{$context->getNamespaces}) {
         if ($self->test_namespace($ns)) {
@@ -308,7 +312,7 @@ sub axis_namespace {
 sub axis_parent {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     my $parent = $context->getParentNode;
     return $results unless $parent;
     if (node_test($self, $parent)) {
@@ -319,9 +323,9 @@ sub axis_parent {
 sub axis_preceding {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     # all preceding nodes in document order, except ancestors
-    
+
     START:
 
     my $parent = $context->getParentNode;
@@ -330,7 +334,7 @@ sub axis_preceding {
     while ($context = $context->getPreviousSibling) {
         axis_descendant_or_self($self, $context, $results);
     }
-    
+
     $context = $parent;
     goto START;
 }
@@ -338,7 +342,7 @@ sub axis_preceding {
 sub axis_preceding_sibling {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     while ($context = $context->getPreviousSibling) {
         if (node_test($self, $context)) {
             $results->push($context);
@@ -349,26 +353,26 @@ sub axis_preceding_sibling {
 sub axis_self {
     my $self = shift;
     my ($context, $results) = @_;
-    
+
     if (node_test($self, $context)) {
         $results->push($context);
     }
 }
-    
+
 sub node_test {
     my $self = shift;
     my $node = shift;
-    
+
     # if node passes test, return true
-    
+
     my $test = $self->{test};
 
     return 1 if $test == test_nt_node;
-        
+
     if ($test == test_any) {
         return 1 if $node->isElementNode && defined $node->getName;
     }
-        
+
     local $^W;
 
     if ($test == test_ncwild) {
@@ -385,7 +389,7 @@ sub node_test {
             my $match_ns = $self->{pp}->get_namespace($prefix, $node);
             if (my $node_nsnode = $node->getNamespace()) {
 #                warn "match: '$self->{literal}' match NS: '$match_ns' got NS: '", $node_nsnode->getValue, "'\n";
-                return 1 if ($match_ns eq $node_nsnode->getValue) &&
+                return 1 if defined $match_ns && ($match_ns eq $node_nsnode->getValue) &&
                         ($name eq $node->getLocalName);
             }
         }
@@ -413,21 +417,21 @@ sub node_test {
             return 1;
         }
     }
-    
+
     return; # fallthrough returns false
 }
 
 sub test_attribute {
     my $self = shift;
     my $node = shift;
-    
+
 #    warn "test_attrib: '$self->{test}' against: ", $node->getName, "\n";
 #    warn "node type: $node->[node_type]\n";
-    
+
     my $test = $self->{test};
-    
+
     return 1 if ($test == test_attr_any) || ($test == test_nt_node);
-        
+
     if ($test == test_attr_ncwild) {
         my $match_ns = $self->{pp}->get_namespace($self->{literal}, $node);
         if (my $node_nsnode = $node->getNamespace()) {
@@ -447,50 +451,50 @@ sub test_attribute {
             return 1 if $node->getName eq $self->{literal};
         }
     }
-    
+
     return; # fallthrough returns false
 }
 
 sub test_namespace {
     my $self = shift;
     my $node = shift;
-    
+
     # Not sure if this is correct. The spec seems very unclear on what
     # constitutes a namespace test... bah!
-    
+
     my $test = $self->{test};
-    
+
     return 1 if $test == test_any; # True for all nodes of principal type
-    
+
     if ($test == test_any) {
         return 1;
     }
     elsif ($self->{literal} eq $node->getExpanded) {
         return 1;
     }
-    
+
     return;
 }
 
 sub filter_by_predicate {
     my $self = shift;
     my ($nodeset, $predicate) = @_;
-    
+
     # See spec section 2.4, paragraphs 2 & 3:
     # For each node in the node-set to be filtered, the predicate Expr
     # is evaluated with that node as the context node, with the number
     # of nodes in the node set as the context size, and with the
     # proximity position of the node in the node set with respect to
     # the axis as the context position.
-    
+
     if (!ref($nodeset)) { # use ref because nodeset has a bool context
         die "No nodeset!!!";
     }
-    
+
 #    warn "Filter by predicate: $predicate\n";
-    
+
     my $newset = XML::XPath::NodeSet->new();
-    
+
     for(my $i = 1; $i <= $nodeset->size; $i++) {
         # set context set each time 'cos a loc-path in the expr could change it
         $self->{pp}->set_context_set($nodeset);
@@ -512,7 +516,7 @@ sub filter_by_predicate {
             }
         }
     }
-    
+
     return $newset;
 }
 

--- a/extlib/boolean.pm
+++ b/extlib/boolean.pm
@@ -1,6 +1,6 @@
 use strict; use warnings;
 package boolean;
-our $VERSION = '0.45';
+our $VERSION = '0.46';
 
 my ($true, $false);
 
@@ -32,6 +32,13 @@ BEGIN {
     $true  = do {bless \$t, 'boolean'};
     $false = do {bless \$f, 'boolean'};
 
+    $true_val  = overload::StrVal($true);
+    $false_val = overload::StrVal($false);
+    $bool_vals = {$true_val => 1, $false_val => 1};
+}
+
+# refaddrs change on thread spawn, so CLONE fixes them up
+sub CLONE {
     $true_val  = overload::StrVal($true);
     $false_val = overload::StrVal($false);
     $bool_vals = {$true_val => 1, $false_val => 1};


### PR DESCRIPTION
- CGI (4.36 to 4.38)
```
4.38 2017-12-01

    [ TESTING ]
    - command_line.t: Avoid -I for libs (GH #224, thanks to cpansprout)

4.37 2017-11-01

    [ FIX ]
    - Fix incorrect quoting of ? in ->url (GH #112, GH #222, with
      thanks to Reuben Thomas)
```

- CGI::Fast (2.12 to 2.13)
```
2.13 2017-11-17
    [TESTING]
    remove use of Test::Deep completely (GH #17)
```
- Class::Accessor (0.34 to 0.51)
```
0.50 2017-10-20
    Thanks to Jonas B. Nielsen for working through the RT queue.
    - patch for speed increase RT#84838
    - patch for faster constructor RT#57353
    - fixed typos for RT#61304 and RT#86422
```
- File::Copy::Recursive (0.38 to 0.40)
```
0.40 Tue Jan 16 10:00:09 2017
    - github Issue #5 - Deep directories pathmk
    - rt 123966 - switch to bsd_glob() since glob() will disappear in perl 5.30
    - rt 123971 - skip symlink tests when the OS does not support symlinks
    - rt 123970 - use Path::Tiny instead of File::Slurp in tests
    - rt 117241 - add test for read only directories

0.39 Fri Dec 29 13:26:12 2017
    - tidy code
    - Change into directory before emptying it
    - Stop emptying/removing a path if it is changed out from underneath us
    - pathrm() fixes
    - Actual unit tests!
```
- HTTP::Message (6.13 to 6.14)
```
6.14      2017-12-20 22:28:48Z
    - Add some useful examples in HTTP::Request (GH #92) (Chase Whitener).
      Batch requests are now explained.
    - PUT and PATCH docs updated (GH #84) (saturdaywalkers)
    - Trim trailing \r from status line so message() doesn't return it (GH #87) (Felipe Gasper)
    - Bring test coverage of HTTP::Config to 100% (GH #85) (Pete Houston)
    - Add 103 Early Hints to HTTP::Status (GH #94) (Tatsuhiko Miyagawa)
```
- JSON (2.96 to 2.97001)
```
2.97001 2017-12-21
    - updated backportPP with JSON::PP 2.97001

2.97000 2017-11-21
    - updated backportPP with JSON::PP 2.97000
    - use 5 digit minor version number for a while to avoid
      confusion
    - fixed is_bool to use blessed() instead of ref()
```
- JSON::PP (2.96 to 2.97001)
```
2.97001 2017-12-21
    - tweak internal number detector to always considers a flagged
      value as a string (GH#35, haarg++)
    - clarify json_pp options (RT-123766; Dan Jacobson)

2.97000 2017-11-21
    - fix is_bool to use blessed() instead of ref() (jwrightecs++)
    - use 5 digit minor version number for a while to avoid confusion
      (GH#33, dansut)
```
- Net::FTPSSL (0.38 to 0.39)
```
0.39 2017/10/23 08:30:00
  - Updated the LISCENSE file to 2017 (from 2015)
  - Changed default from TLS v1.0 to TLS v1.2 and rearranged the POD a bit.
  - Started depreciating useSSL.  Now prints out warning if used!  Warning
    says to use option "SSL_version" instead.
```
- Try::Tiny (0.28 to 0.30)
```
0.30      2017-12-21 07:23:03Z
  - expand "when" test skippage to more perl versions

0.29      2017-12-19 03:51:26Z
  - skip tests of "when" and "given/when" usage for perl 5.27.7 *only* (see
    RT#123908)
```
- URI (1.72 to 1.73)
```
1.73      2018-01-09 06:42:51Z
    - Update documentation for URI::_punycode (GH Issue #45)
```
- boolean (0.45 to 0.46)
```
0.46 Fri Jul  8 17:14:32 UTC 2016
 - Apply PR/14 @dagolden++
 - Adds CLONE method for thread safety
```
- LWP (6.26 to 6.31)
```
6.31      2017-12-11 01:55:53Z
    - fix version numbering (RT#123841)

6.30      2017-12-07
    - Use tr/// instead of s/// where appropriate (Ville Skyttﾃ､) (GH #265)
    - Use parent -norequire instead of base to not look for external
      dependencies (Fabian Zeindler) (GH #259)
    - Fix run_handlers to allow assigning to the request / response (Gianni
      Ceccarelli) (GH #274)

6.29      2017-11-06
    - Fix some version numbers

6.28      2017-11-06
    - Remove last use of Geopt::Std (Sergey Remanov) (GH #267)
    - Include unmatched connect error in status string (Patrik Lundin) (GH #269)
    - Fix insecure open FILEHANDLE,EXPR (Takumi Akiyama) (GH #270)

6.27      2017-09-21
    - Switch to Getopt::Long in lwp-download (GH #262)
    - Fix lwp-request -C (GH #261)
    - Hide LWP::Protocol::http::Socket, LWP::Protocol::http::SocketMethods and
      LWP::Debug::TraceHTTP::Socket from PAUSE
    - Add tests for the "get" & "head" functions (GH #252)
    - Update lwpcook.pod (GH #256)
    - Handle undefined values in ->credentials (GH #157)
    - Fix lwp-mirror options checks.
    - Update bin/ scripts to use $LWP::VERSION instead of ->Version()
    - Improve lwp-download --help (GH #262)
```