### PR TITLE
Remove can_add option from content type field. MTC-25080

### DIFF
--- a/lib/MT/ContentFieldType.pm
+++ b/lib/MT/ContentFieldType.pm
@@ -80,7 +80,6 @@ sub _content_type_registry {
                 required
                 display
                 multiple
-                can_add
                 max
                 min
                 source

--- a/tmpl/cms/content_field_type_options/content_type.tmpl
+++ b/tmpl/cms/content_field_type_options/content_type.tmpl
@@ -22,12 +22,6 @@
   </mtapp:ContentFieldOption>
 
   <mtapp:ContentFieldOption
-     id="content_type-can_add"
-     label="<__trans phrase="Allow users to create a new content data?">">
-    <input ref="can_add" type="checkbox" class="mt-switch form-control" id="content_type-can_create" name="can_add" checked={ options.can_add }><label for="content_type-can_create"><__trans phrase="Allow users to create a new content data?"></label>
-  </mtapp:ContentFieldOption>
-
-  <mtapp:ContentFieldOption
      id="content_type-source"
      required="1"
      label="<__trans phrase="Source Content Type">">


### PR DESCRIPTION
https://movabletype.atlassian.net/browse/MTC-25080