### PR TITLE
Revert removed ss_validator for number field. MTC-25123

### DIFF
--- a/lib/MT/ContentFieldType.pm
+++ b/lib/MT/ContentFieldType.pm
@@ -186,6 +186,7 @@ sub _number_registry {
         field_html_params =>
             '$Core::MT::ContentFieldType::Number::field_html_params',
         replaceable  => 1,
+        ss_validator => '$Core::MT::ContentFieldType::Number::ss_validator',
         list_props   => {
             number => {
                 base  => '__virtual.double',


### PR DESCRIPTION
https://github.com/movabletype/movabletype/commit/295d28b5b94adadf59efc01f4d649754d9219faa#diff-0451c02b9d39a42177d8db644fe05d80L188