### PR TITLE
Fix a bug where username filter causes odd number elements in hash wa…

### DIFF
--- a/lib/MT/CMS/User.pm
+++ b/lib/MT/CMS/User.pm
@@ -1336,7 +1336,7 @@ PERMCHECK: {
                     code      => $hasher,
                     params    => $params,
                     template  => 'include/listing_panel.tmpl',
-                    pre_build => $type eq 'site' ? $pre_build : (),
+                    $type eq 'site' ? ( pre_build => $pre_build ) : (),
                     $app->param('search') ? ( no_limit => 1 ) : (),
                 }
             );


### PR DESCRIPTION
On Grant Permissions dialog, username filter request causes following warning.

> Odd number of elements in anonymous hash at /app/movabletype/lib/MT/CMS/User.pm line 1346.

<img width="794" alt="2018-09-11 16 41 51" src="https://user-images.githubusercontent.com/442658/45345705-0ec79f80-b5e2-11e8-9fc8-546536edaf6c.png">
