### PR TITLE
Prevent Use of uninitialized value warning

### DIFF
--- a/lib/MT/CMS/Blog.pm
+++ b/lib/MT/CMS/Blog.pm
@@ -2044,7 +2044,7 @@ sub post_save {
         my ( $x, $y, $remember )
             = split( /::/, $cookies{ $app->user_cookie() }->value );
         my $cookie = $cookies{'commenter_id'};
-        my $cookie_value = $cookie ? $cookie->value : '';
+        my $cookie_value = $cookie ? $cookie->value : ':';
         my ( $id, $blog_ids ) = split( ':', $cookie_value );
         if ( $blog_ids ne 'S' && $blog_ids ne 'N' ) {
             $blog_ids .= ",'" . $obj->id . "'";


### PR DESCRIPTION
This change prevents following warning on site creation.

> Use of uninitialized value $blog_ids in string ne at /app/movabletype/lib/MT/CMS/Blog.pm line 2049.

### Steps to reproduce the issue

1. Delete a cookie named 'commenter_id'
2. Sign in to MT and create new site