### PR TITLE
Muting errors on unchanged content data save

### DIFF
--- a/lib/MT/ContentData.pm
+++ b/lib/MT/ContentData.pm
@@ -1588,7 +1588,7 @@ sub gather_changed_cols {
         }
     }
 
-    $obj->{changed_revisioned_cols} = @$changed_cols ? $changed_cols : undef;
+    $obj->{changed_revisioned_cols} = $changed_cols;
 
     1;
 }


### PR DESCRIPTION
The patch prevents the following errors.

Can't use an undefined value as an ARRAY reference at /app/movabletype/lib/MT/Revisable.pm line 125.
Can't use an undefined value as an ARRAY reference at /app/movabletype/lib/MT/Revisable/Local.pm line 119.

### Steps to reproduce the behavior

1. Create a content data.
2. Don't change anything and save again.
