### PR TITLE
Fix category precedence MTC-26097 MTC-26104

### DIFF
--- a/lib/MT/Template/Tags/ContentType.pm
+++ b/lib/MT/Template/Tags/ContentType.pm
@@ -177,6 +177,8 @@ sub _hdlr_contents {
             ? $ctx->stash('category')
             : $ctx->stash('archive_category');
         if ( $cat && $cat->class eq $cat_class_type ) {
+            my $cat_field = MT::ContentField->load($cat_field_id);
+            my $has_same_field = exists $fields{ $cat_field->name };
             push @{ $args{joins} },
                 MT::ContentFieldIndex->join_on(
                 'content_data_id',
@@ -184,7 +186,7 @@ sub _hdlr_contents {
                     value_integer    => $cat->id
                 },
                 { alias => 'cat_cf_idx' }
-                );
+                ) unless $has_same_field;
         }
     }
 

--- a/php/lib/mtdb.base.php
+++ b/php/lib/mtdb.base.php
@@ -4498,7 +4498,9 @@ abstract class MTDatabase {
                 if($cat_fields){
                     $cf = $cat_fields[0];
                     if (isset($args['category'])){
-                        $fields[$cf->cf_name] = $args['category'];
+                        if (!array_key_exists($cf->cf_name, $fields)) {
+                            $fields[$cf->cf_name] = $args['category'];
+                        }
                     } else {
                         $alias = 'cf_idx_' . $cf->id;
                         require_once "content_field_type_lib.php";

--- a/t/mt7/tag/contents-with-fields-contenttype-category-based.t
+++ b/t/mt7/tag/contents-with-fields-contenttype-category-based.t
@@ -1,0 +1,119 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../../lib";    # t/lib
+use Test::More;
+use MT::Test::Env;
+our $test_env;
+
+BEGIN {
+    $test_env = MT::Test::Env->new;
+    $ENV{MT_CONFIG} = $test_env->config_file;
+}
+
+use Test::Base;
+use MT::Test::ArchiveType;
+
+use MT;
+use MT::Test;
+my $app = MT->instance;
+
+$test_env->prepare_fixture('archive_type');
+
+filters {
+    MT::Test::ArchiveType->filter_spec
+};
+
+my @maps = grep {$_->archive_type =~ /^ContentType-Category$/} MT::Test::ArchiveType->template_maps;
+
+my $objs = MT::Test::Fixture::ArchiveType->load_objs;
+MT::Test::ArchiveType->vars->{blog_id} = $objs->{blog_id};
+
+MT::Test::ArchiveType->run_tests(@maps);
+
+done_testing;
+
+__END__
+
+=== mt:Contents without a field modifier (MTC-26097/26104)
+--- stash
+{
+    cd => 'cd_same_apple_orange_peach',
+    cat_field => 'cf_same_catset_fruit',
+    category => 'cat_apple',
+}
+--- template
+<mt:Contents content_type="ct_with_same_catset" blog_id="[% blog_id %]"><mt:ContentLabel>
+</mt:Contents>
+--- expected_contenttype_category
+cd_same_apple_orange
+cd_same_apple_orange_peach
+
+=== mt:Contents with the same field modifier as the one set in the template map (MTC-26097/26104)
+--- stash
+{
+    cd => 'cd_same_apple_orange_peach',
+    cat_field => 'cf_same_catset_fruit',
+    category => 'cat_apple',
+}
+--- template
+<mt:Contents content_type="ct_with_same_catset" blog_id="[% blog_id %]" field:cf_same_catset_fruit="cat_apple"><mt:ContentLabel>
+</mt:Contents>
+--- expected_contenttype_category
+cd_same_apple_orange
+cd_same_apple_orange_peach
+
+=== mt:Contents with a different modifier from the one set in the template map (MTC-26097/26104)
+--- stash
+{
+    cd => 'cd_same_apple_orange_peach',
+    cat_field => 'cf_same_catset_fruit',
+    category => 'cat_apple',
+}
+--- template
+<mt:Contents content_type="ct_with_same_catset" blog_id="[% blog_id %]" field:cf_same_catset_other_fruit="cat_peach"><mt:ContentLabel>
+</mt:Contents>
+--- expected
+cd_same_apple_orange_peach
+
+=== mt:Contents with the same modifier with a different category (should override) (MTC-26097/26104)
+--- stash
+{
+    cd => 'cd_same_apple_orange_peach',
+    cat_field => 'cf_same_catset_fruit',
+    category => 'cat_apple',
+}
+--- template
+<mt:Contents content_type="ct_with_same_catset" blog_id="[% blog_id %]" field:cf_same_catset_fruit="cat_peach"><mt:ContentLabel>
+</mt:Contents>
+--- expected
+cd_same_peach
+
+=== mt:Contents with two consistent modifiers (same as the related content data) (MTC-26097/26104)
+--- stash
+{
+    cd => 'cd_same_apple_orange_peach',
+    cat_field => 'cf_same_catset_fruit',
+    category => 'cat_apple',
+}
+--- template
+<mt:Contents content_type="ct_with_same_catset" blog_id="[% blog_id %]" field:cf_same_catset_fruit="cat_apple" field:cf_same_catset_other_fruit="cat_peach"><mt:ContentLabel>
+</mt:Contents>
+--- expected
+cd_same_apple_orange_peach
+
+=== mt:Contents with two consistent modifiers (different from the related content data) (MTC-26097/26104)
+--- stash
+{
+    cd => 'cd_same_apple_orange_peach',
+    cat_field => 'cf_same_catset_fruit',
+    category => 'cat_apple',
+}
+--- template
+<mt:Contents content_type="ct_with_same_catset" blog_id="[% blog_id %]" field:cf_same_catset_fruit="cat_apple" field:cf_same_catset_other_fruit="cat_orange"><mt:ContentLabel>
+</mt:Contents>
+--- expected
+cd_same_apple_orange
+

--- a/t/mt7/tag/contents-with-fields.t
+++ b/t/mt7/tag/contents-with-fields.t
@@ -138,8 +138,8 @@ for my $id ( 1 .. 3 ) {
         blog_id         => $blog_id,
         category_set_id => $catset->id,
         label           => "Category $id-1",
-        ),
-        push @cats,
+        );
+    push @cats,
         MT::Test::Permission->make_category(
         blog_id         => $blog_id,
         category_set_id => $catset->id,
@@ -485,8 +485,8 @@ Content Data9
 <mt:Contents content_type="Content Type with Categories" blog_id="[% blog_id %]" field:cf_category_1="Category 1-1" sort_by="field:single"><mt:ContentLabel>
 </mt:Contents>
 --- expected
-Content Data8
 Content Data7
+Content Data6
 
 === mt:Contents with another category field (MTC-26080/26092)
 --- blog_id
@@ -495,8 +495,8 @@ Content Data7
 <mt:Contents content_type="Content Type with Categories" blog_id="[% blog_id %]" field:cf_category_2="Category 2-1" sort_by="field:single"><mt:ContentLabel>
 </mt:Contents>
 --- expected
-Content Data8
 Content Data7
+Content Data6
 
 === mt:Contents with two category fields (MTC-26080/26092)
 --- blog_id
@@ -505,8 +505,8 @@ Content Data7
 <mt:Contents content_type="Content Type with Categories" blog_id="[% blog_id %]" field:cf_category_1="Category 1-1" field:cf_category_2="Category 2-1" sort_by="field:single"><mt:ContentLabel>
 </mt:Contents>
 --- expected
-Content Data8
 Content Data7
+Content Data6
 
 === mt:Contents with two different category fields (MTC-26080/26092)
 --- blog_id
@@ -525,7 +525,7 @@ Content Data7
 </mt:Contents>
 --- expected
 Content Data7
-Content Data8
+Content Data6
 
 === mt:Contents with two different category fields, sort by category (MTC-26080/26092)
 --- blog_id


### PR DESCRIPTION
to allow a category specified in a field modifier override the category specified in the template map when both categories belong to the same category set