### PR TITLE
Add test. MTC-26210

### DIFF
--- a/lib/MT/Template/Tags/Entry.pm
+++ b/lib/MT/Template/Tags/Entry.pm
@@ -355,7 +355,8 @@ sub _hdlr_entries {
             'recently_commented_on', 'include_subcategories',
             'include_blogs',         'exclude_blogs',
             'blog_ids',              'include_websites',
-            'exclude_websites',      'site_ids'
+            'exclude_websites',      'site_ids',
+            'include_sites',         'exclude_sites'
             )
         {
             if ( exists( $args->{$args_key} ) ) {


### PR DESCRIPTION
マージの順番を間違えて、マージ漏れがあるので再度PR。