### PR TITLE
Use unique content field names to test unique_id correctly

### DIFF
--- a/t/mt7/content_field.t
+++ b/t/mt7/content_field.t
@@ -23,6 +23,7 @@ subtest 'set unique_id' => sub {
     my $cf = MT::ContentField->new(
         blog_id         => 1,
         content_type_id => 1,
+        name            => 'test1',
     );
 
     $cf->unique_id($unique_id);
@@ -40,6 +41,7 @@ subtest 'generate unique_id automatically' => sub {
     my $cf = MT::ContentField->new(
         blog_id         => 1,
         content_type_id => 1,
+        name            => 'test2',
     );
     $cf->save or die $cf->errstr;
     ok( $cf->unique_id, 'unique_id is generated' );
@@ -50,12 +52,14 @@ subtest 'forbid creating content_field with not unique unique_id' => sub {
     my $cf1 = MT::ContentField->new(
         blog_id         => 1,
         content_type_id => 1,
+        name            => 'test3-1',
     );
     $cf1->save or die $cf1->errstr;
 
     my $cf2 = MT::ContentField->new(
         blog_id         => 1,
         content_type_id => 1,
+        name            => 'test3-2',
     );
     $cf2->unique_id( $cf1->unique_id );
     $cf2->save;


### PR DESCRIPTION
t/mt7/content_field.t currently passes because of a bug in Data::ObjectDriver that generates a term such as "name = NULL" (and thus MT::ContentField::_exist_same_name always returns false). Each content field created in this test should have a unique name.