### PR TITLE
Suppress warning

### DIFF
--- a/lib/MT/App.pm
+++ b/lib/MT/App.pm
@@ -3557,7 +3557,7 @@ sub load_widgets {
             $order
                 = $order && ref $order eq 'HASH'
                 ? $all_widgets->{$widget_id}{order}{$scope_type}
-                : $order * 100;
+                : ( $order || 0 ) * 100;
             $order = $order_num = $order_num + 100 unless defined $order;
             $widget_param->{order} = $order;
             $resave_widgets = 1;


### PR DESCRIPTION
> Use of uninitialized value $order in multiplication (*) at /app/movabletype/lib/MT/App.pm line 3559.