### PR TITLE
Silence active statement warnings

### DIFF
--- a/lib/MT/Asset.pm
+++ b/lib/MT/Asset.pm
@@ -821,15 +821,13 @@ sub remove {
 
         # remove children.
         my $class = ref $asset;
-        my $iter  = __PACKAGE__->load_iter(
+        my @parents = __PACKAGE__->load(
             { parent => $asset->id, class => '*' } );
-        while ( my $a = $iter->() ) {
-            $a->SUPER::remove;
-        }
+        $_->remove for @parents;
 
         # Remove MT::ObjectAsset records
         $class = MT->model('objectasset');
-        $iter = $class->load_iter( { asset_id => $asset->id } );
+        my $iter = $class->load_iter( { asset_id => $asset->id } );
         while ( my $o = $iter->() ) {
             $o->remove;
         }

--- a/lib/MT/Asset.pm
+++ b/lib/MT/Asset.pm
@@ -824,7 +824,7 @@ sub remove {
         my $iter  = __PACKAGE__->load_iter(
             { parent => $asset->id, class => '*' } );
         while ( my $a = $iter->() ) {
-            $a->remove;
+            $a->SUPER::remove;
         }
 
         # Remove MT::ObjectAsset records

--- a/t/data_api/237-api-endpoint-asset-v3.t
+++ b/t/data_api/237-api-endpoint-asset-v3.t
@@ -1159,7 +1159,24 @@ sub suite {
         {    # Blog.
             path      => '/v3/sites/1/assets/1',
             method    => 'DELETE',
-            setup     => sub { die if !$app->model('asset')->load(1) },
+            setup     => sub {
+                die if !$app->model('asset')->load(1);
+
+                # add grandchilden
+                my $asset = $app->model('asset')->load(100) or die $!;
+                $asset->set_values(
+                    {   id     => 1000,
+                        parent => 100,
+                    }
+                );
+                $asset->save or die $asset->errstr;
+                $asset->set_values(
+                    {   id     => 10000,
+                        parent => 1000,
+                    }
+                );
+                $asset->save or die $asset->errstr;
+            },
             callbacks => [
                 {   name =>
                         'MT::App::DataAPI::data_api_delete_permission_filter.asset',
@@ -1172,6 +1189,11 @@ sub suite {
             complete => sub {
                 my $deleted = MT->model('asset')->load(1);
                 is( $deleted, undef, 'deleted' );
+
+                # grandchilden should be removed as well
+                my @grandchilden = MT->model('asset')
+                    ->load( { class => '*', parent => [ 100, 1000 ] } );
+                ok !@grandchilden, "no grandchildren";
             },
         },
         {    # System.


### PR DESCRIPTION
cf. t/data_api/237-api-endpoint-asset-v3.t
```
prepare_cached(SELECT asset_id, asset_blog_id, asset_class, asset_created_by, asset_created_on, asset_description, asset_file_ext, asset_file_name, asset_file_path, asset_label, asset_mime_type, asset_modified_by, asset_modified_on, asset_parent, asset_url
FROM mt_asset
WHERE (asset_parent = ?)
ORDER BY asset_id ASC
) statement handle DBI::st=HASH(0xb6e2cd8) still Active at .../extlib/Data/ObjectDriver/Driver/DBI.pm line 61.
```
This warning happens because ```$a->remove``` starts another iteration.
