### PR TITLE
MT::Util::is_valid_email considers ```mt@localhost``` invalid

### DIFF
--- a/t/lib/MT/Test/Env.pm
+++ b/t/lib/MT/Test/Env.pm
@@ -91,7 +91,7 @@ sub write_config {
         DefaultLanguage      => 'en_US',
         StaticWebPath        => '/mt-static/',
         StaticFilePath       => 'TEST_ROOT/mt-static',
-        EmailAddressMain     => 'mt@localhost',
+        EmailAddressMain     => 'mt@localhost.localdomain',
         WeblogTemplatesPath  => 'MT_HOME/default_templates',
         ImageDriver          => $image_driver,
         MTVersion            => MT->version_number,


### PR DESCRIPTION
because there's no dot in it