### PR TITLE
Remove duplicated "return."

### DIFF
--- a/lib/MT/App/Search.pm
+++ b/lib/MT/App/Search.pm
@@ -560,7 +560,7 @@ sub search_terms {
     if ( $app->param('archive_type') ) {
         my $at       = $app->param('archive_type');
         my $archiver = MT->publisher->archiver($at);
-        return return $app->errtrans('Invalid archive type')
+        return $app->errtrans('Invalid archive type')
             unless ( $archiver || $at eq 'Index' );
     }
 
@@ -926,8 +926,7 @@ sub load_search_tmpl {
 
             if ( my $at = $app->param('archive_type') ) {
                 my $archiver = MT->publisher->archiver($at);
-                return
-                    return $app->errtrans(
+                return $app->errtrans(
                     'You must pass a valid archive_type with the template_id')
                     unless ( $archiver || $at eq 'Index' );
 

--- a/lib/MT/App/Search/ContentData.pm
+++ b/lib/MT/App/Search/ContentData.pm
@@ -314,7 +314,7 @@ sub search_terms {
     if ( $app->param('archive_type') ) {
         my $at       = $app->param('archive_type');
         my $archiver = MT->publisher->archiver($at);
-        return return $app->errtrans('Invalid archive type')
+        return $app->errtrans('Invalid archive type')
             unless ( $archiver || $at eq 'Index' );
     }
 

--- a/lib/MT/CMS/Common.pm
+++ b/lib/MT/CMS/Common.pm
@@ -93,7 +93,7 @@ sub save {
     if ( !$author->is_superuser ) {
         if ( ( $type ne 'author' ) && ( $type ne 'template' ) )
         {    # for authors, blog-ctx $perms is not relevant
-            return return $app->permission_denied()
+            return $app->permission_denied()
                 if !$perms && $id;
         }
 


### PR DESCRIPTION
Remove duplicated "return."
It doesn't make sense why "return" words are repeated.
If these are needed, could you tell me why?