### PR TITLE
Fix a uuv warning. MTC-27233

### DIFF
--- a/lib/MT/CMS/Blog.pm
+++ b/lib/MT/CMS/Blog.pm
@@ -2052,7 +2052,7 @@ sub post_save {
         my ( $x, $y, $remember )
             = split( /::/, $cookies{ $app->user_cookie() }->value );
         my $cookie = $cookies{'commenter_id'};
-        my $cookie_value = $cookie ? $cookie->value : '';
+        my $cookie_value = $cookie ? $cookie->value : ':';
         my ( $id, $blog_ids ) = split( ':', $cookie_value );
         if ( $blog_ids ne 'S' && $blog_ids ne 'N' ) {
             $blog_ids .= ",'" . $obj->id . "'";


### PR DESCRIPTION
I think the empty value for "commenter_id" is more appropriate for ":" than for "".