### PR TITLE
[MT6] Backport adapter.js for TinyMCE5 from MT7 MTC-27489

### DIFF
--- a/mt-static/plugins/TinyMCE5/lib/js/adapter.js
+++ b/mt-static/plugins/TinyMCE5/lib/js/adapter.js
@@ -168,9 +168,9 @@ $.extend(MT.Editor.TinyMCE.prototype, MT.Editor.prototype, {
         config['selector'] = '#' + adapter.id;
 
         if (adapter.commonOptions['content_css_list'].length > 0){
-          config['content_css'] =
-              (config['content_css'] + ',' + adapter.commonOptions['content_css_list'].join(','))
-              .replace(/^,+|,+$/g, '').replace(/"/g, '&qquot;');
+            config['content_css'] =
+            ((config['content_css'] ? config['content_css'] + ',' : '') + adapter.commonOptions['content_css_list'].join(','))
+            .replace(/^,+|,+$/g, '').replace(/"/g, '&qquot;');
         }
 
         config['body_class'] =


### PR DESCRIPTION
cf. https://github.com/movabletype/movabletype/commit/1852ef624008a7a24558176b992ffedfc9f8b48c