### PR TITLE
Make DBPassword configurable via PERL_TEST_MYSQLPOOL_DSN.

### DIFF
--- a/t/lib/MT/Test/Env.pm
+++ b/t/lib/MT/Test/Env.pm
@@ -317,7 +317,7 @@ sub _connect_info_mysql {
         Database     => "mt_test",
     );
 
-    if ( my $dsn = $ENV{PERL_TEST_MYSQLPOOL_DSN} ) {
+    if ( my $dsn = $ENV{MT_TEST_DSN} || $ENV{PERL_TEST_MYSQLPOOL_DSN} ) {
         my $dbh = DBI->connect($dsn) or die $DBI::errstr;
         $self->_prepare_mysql_database($dbh);
         $dsn =~ s/^DBI:mysql://i;

--- a/t/lib/MT/Test/Env.pm
+++ b/t/lib/MT/Test/Env.pm
@@ -336,6 +336,9 @@ sub _connect_info_mysql {
         if ( $opts{port} ) {
             $info{DBPort} = $opts{port};
         }
+        if ( $opts{password} ) {
+            $info{DBPassword} = $opts{password};
+        }
         $self->{dsn}
             = "dbi:mysql:" . ( join ";", map {"$_=$opts{$_}"} keys %opts );
 


### PR DESCRIPTION
### Motivation

I want to run a test with mt-dev with the following command in order to test with an arbitrary database instance.

```bash
[docker-container] $ PERL_TEST_MYSQLPOOL_DSN='dbi:mysql:host=db;user=root;password=password' prove -It/lib t/*.t
```

In the normal case, I know that we can run unit tests directly using docker run with the following command.

```bash
[local] $ docker run --rm --entrypoint '' -v `pwd`:/mt -w /mt movabletype/test:perl-5.28 prove -j4 -PMySQLPool=MT::Test::Env -It/lib t/*.t
```