### PR TITLE
[MT7] Fix/list template warnings

### DIFF
--- a/lib/MT/App/CMS.pm
+++ b/lib/MT/App/CMS.pm
@@ -4330,7 +4330,7 @@ sub add_to_favorite_websites {
     my @current = @{ $auth->favorite_websites || [] };
 
     return if @current && ( $current[0] == $fav );
-    @current = grep { $_ != $fav } @current;
+    @current = grep { $_ && $_ != $fav } @current;
     unshift @current, $fav;
     @current = @current[ 0 .. 9 ]
         if @current > 10;

--- a/lib/MT/CMS/Template.pm
+++ b/lib/MT/CMS/Template.pm
@@ -794,8 +794,7 @@ sub edit {
             }
         }
     }
-    $param->{publish_queue_available}
-        = eval 'require List::Util; require Scalar::Util; 1;';
+    $param->{publish_queue_available} = eval {require List::Util; require Scalar::Util; 1;};
 
     return $app->return_to_dashboard( redirect => 1 )
         if $param->{type} =~ /['"<>]/;
@@ -1558,7 +1557,7 @@ sub preview {
     $app->run_callbacks( 'cms_pre_preview.template', $app, $preview_tmpl,
         \@data );
 
-    my $has_hires = eval 'require Time::HiRes; 1' ? 1 : 0;
+    my $has_hires = eval { require Time::HiRes; 1 } ? 1 : 0;
     my $start_time = $has_hires ? Time::HiRes::time() : time;
 
     my $ctx = $preview_tmpl->context;
@@ -1753,8 +1752,7 @@ sub _generate_map_table {
     my $template = MT::Template->load($template_id);
     my $tmpl     = $app->load_tmpl('include/archive_maps.tmpl');
     my $maps = _populate_archive_loop( $app, $blog, $template, $new_map_id );
-    $tmpl->param( publish_queue_available => eval
-            'require List::Util; require Scalar::Util; 1;' );
+    $tmpl->param( publish_queue_available => eval { require List::Util; require Scalar::Util; 1; } );
     $tmpl->param( template_map_loop => $maps ) if @$maps;
     my $html = $tmpl->output();
 

--- a/lib/MT/CMS/Template.pm
+++ b/lib/MT/CMS/Template.pm
@@ -1126,7 +1126,7 @@ sub list {
         if ( ref $ts ) {
             $set = $ts->{templates};
         }
-        elsif ( $ts ne 'mt_blog' ) {
+        elsif ( $ts && $ts ne 'mt_blog' ) {
             $set = MT->registry(
                 template_sets => $blog->template_set => 'templates' );
         }


### PR DESCRIPTION
It silences following warnings in template list on upgraded sites.

```
Use of uninitialized value $ts in string ne at lib/MT/CMS/Template.pm line 1130.
Use of uninitialized value $p in exists at lib/MT/Component.pm line 674.
```

The patch seems to change default inheritance of system templates on such sites.
