### PR TITLE
[MT7] use Web::Query::LibXML

### DIFF
--- a/t/lib/MT/Test/Role/WebQuery.pm
+++ b/t/lib/MT/Test/Role/WebQuery.pm
@@ -1,11 +1,11 @@
 package MT::Test::Role::WebQuery;
 
 use Role::Tiny;
-use Web::Query;
+use Web::Query::LibXML;
 
 sub wq_find {
     my ( $self, $selector ) = @_;
-    my $wq = Web::Query->new( $self->content );
+    my $wq = Web::Query::LibXML->new( $self->content );
     $wq->find($selector);
 }
 


### PR DESCRIPTION
Web::Query doesn't handle 'svg > title' properly.

```
use strict;
use warnings;
use feature qw(say);

my $str = '';
$str .= $_ while (<DATA>);

# https://developer.mozilla.org/ja/docs/Web/SVG/Element/title

my $selector = '#test';
{
    use Web::Query::LibXML;
    my $b = Web::Query::LibXML->new($str);
    say 'Web::Query::LibXML';
    say "'". $b->find($selector)->eq(0)->html. "'";
    say "'". $b->find($selector)->eq(0)->as_html. "'";
}
{
    use Web::Query;
    my $b = Web::Query->new($str);
    say 'Web::Query';
    say "'". $b->find($selector)->eq(0)->html. "'";
    say "'". $b->find($selector)->eq(0)->as_html. "'";
}

# Web::Query::LibXML
# '<svg class="mt-icon--inverse" role="img"><title>Open mobile global menu</title></svg>'
# '<a id="test"><svg class="mt-icon--inverse" role="img"><title>Open mobile global menu</title></svg></a>'
# Web::Query
# '<svg class="mt-icon--inverse" role="img"></svg>'
# '<a id="test"><svg class="mt-icon--inverse" role="img"></svg></a>'


__DATA__
<!DOCTYPE html>
<html lang="ja">
<body>
<a id="test"><svg role="img" class="mt-icon--inverse"><title>Open mobile global menu</title></svg></a>
</body>
</html>

```