### PR TITLE
[MT6]  Remove the `branding` setting and use the default value. MTC-28055

### DIFF
--- a/mt-static/plugins/TinyMCE5/lib/js/adapter.js
+++ b/mt-static/plugins/TinyMCE5/lib/js/adapter.js
@@ -38,7 +38,6 @@ $.extend(MT.Editor.TinyMCE, MT.Editor, {
         language: $('html').attr('lang'),
         
         menubar: false,
-        branding: false,
         icons: 'mt',
         icons_url: StaticURI + 'plugins/TinyMCE5/lib/js/tinymce/icons.js',
 


### PR DESCRIPTION
https://www.tiny.cloud/docs/configure/editor-appearance/#branding