### PR TITLE
[MT7] Remove the `branding` setting and use the default value. MTC-28055

### DIFF
--- a/mt-static/plugins/TinyMCE/lib/js/adapter.js
+++ b/mt-static/plugins/TinyMCE/lib/js/adapter.js
@@ -20,7 +20,6 @@
             theme: "modern",
             skin: 'lightgray',
             menubar: false,
-            branding: false,
             forced_root_block: 'p',
             resize: true,
 

--- a/mt-static/plugins/TinyMCE/lib/js/adapter.js
+++ b/mt-static/plugins/TinyMCE/lib/js/adapter.js
@@ -20,6 +20,7 @@
             theme: "modern",
             skin: 'lightgray',
             menubar: false,
+            branding: false,
             forced_root_block: 'p',
             resize: true,
 

--- a/mt-static/plugins/TinyMCE5/lib/js/adapter.js
+++ b/mt-static/plugins/TinyMCE5/lib/js/adapter.js
@@ -37,7 +37,6 @@
   
             language: $('html').attr('lang'),
             menubar: false,
-            branding: false,
             forced_root_block: 'p',
             resize: true,
             icons: 'mt',


### PR DESCRIPTION
https://www.tiny.cloud/docs/configure/editor-appearance/#branding