### PR TITLE
Revert "[MT6] Prevent a weird package name from being evaluated MTC-28188"

### DIFF
--- a/lib/MT.pm
+++ b/lib/MT.pm
@@ -3065,7 +3065,7 @@ sub effective_captcha_provider {
 
 sub handler_to_coderef {
     my $pkg = shift;
-    my ( $name, $delayed, $allow_string_sub ) = @_;
+    my ( $name, $delayed ) = @_;
 
     return $name if ref($name) eq 'CODE';
     return undef unless defined $name && $name ne '';
@@ -3085,7 +3085,7 @@ sub handler_to_coderef {
             $component = $1;
         }
     }
-    if ( $name =~ m/^\s*sub\s*\{/s && ($allow_string_sub || MT->config('ForceAllowStringSub'))) {
+    if ( $name =~ m/^\s*sub\s*\{/s ) {
         $code = eval $name or die $@;
 
         if ($component) {
@@ -3110,7 +3110,6 @@ sub handler_to_coderef {
     else {
         $hdlr_pkg =~ s/::[^:]+$//;
     }
-    die "Illegal package name: $hdlr_pkg" unless $hdlr_pkg =~ /\A[A-Za-z][A-Za-z0-9_]*(?:(?:::|')[A-Za-z0-9_]+)*\z/;
     if ( !defined(&$name) && !$pkg->can('AUTOLOAD') ) {
 
         # The delayed option will return a coderef that delays the loading

--- a/lib/MT/Component.pm
+++ b/lib/MT/Component.pm
@@ -156,7 +156,6 @@ sub load_registry {
     my $y = eval { MT::Util::YAML::LoadFile($path) }
         or die "Error reading $path: "
         . ( MT::Util::YAML->errstr || $@ || $! );
-    __deep_codify_string_sub($c, $y);
     return $y;
 }
 
@@ -683,7 +682,6 @@ sub registry {
                                 or die "Error reading $f: "
                                 . ( MT::Util::YAML->errstr || $@ || $! );
                             if ($y) {
-                                __deep_codify_string_sub($c, $y);
                                 __deep_localize_labels( $c, $y )
                                     if ref $y eq 'HASH';
                                 $r->{$p} = $y;
@@ -738,18 +736,6 @@ sub registry {
         }
         return @list ? \@list : undef;
     }
-}
-
-sub __deep_codify_string_sub {
-    my ($c, $data) = @_;
-    require Data::Visitor::Tiny;
-    Data::Visitor::Tiny::visit($data, sub {
-        my ($key, $valueref) = @_;
-        if ($$valueref && $$valueref =~ /sub\s*\{/s) {
-            my $code = MT->handler_to_coderef($$valueref, undef, 1);
-            $$valueref = $code if $code;
-        }
-    });
 }
 
 sub __deep_localize_labels {

--- a/lib/MT/Core.pm
+++ b/lib/MT/Core.pm
@@ -2154,7 +2154,6 @@ BEGIN {
             'BinZipPath' => undef,
             'BinUnzipPath' => undef,
             'DisableImagePopup' => undef,
-            'ForceAllowStringSub' => undef,
         },
         upgrade_functions => \&load_upgrade_fns,
         applications      => {


### PR DESCRIPTION
Reverts movabletype/movabletype#2001