### PR TITLE
fix php tag test to avoid "doesnt look much like a regex to me" error

### DIFF
--- a/t/lib/MT/Test/Tag.pm
+++ b/t/lib/MT/Test/Tag.pm
@@ -197,6 +197,8 @@ SKIP: {
                     }
                 }
                 my $expected_src = $block->$expected_method // '';
+                my $expected_ref = ref($expected_src);
+
                 $expected_src =~ s/\\r/\\n/g;
                 $expected_src =~ s/\r/\n/g;
 
@@ -206,11 +208,11 @@ SKIP: {
 
                 local $TODO = "may fail" if $expected_method =~ /^expected_(?:php_)?todo/;
 
-                my $expected_ref = ref($expected_src);
                 my $expected     = _filter_vars($expected_src);
                 my $name         = $test_name_prefix . $block->name . ' - dynamic';
 
                 if ($expected_ref && $expected_ref eq 'Regexp') {
+                    $expected = qr{$expected} if ref($expected) ne 'Regexp';
                     like($got, $expected, $name);
                 } else {
                     is($got, $expected, $name);


### PR DESCRIPTION
`--- expedted regexp` を指定したタグテストで、かつ、内容に改行などが含まれていた場合、PHPのときだけ文字列置換が入り、$expected が Regexpリファレンスから文字列に変わってしまい、 `like` のテストに `doesn't look much like a regex to me` と怒られるので、 `qr{$expected}` で再度Regexpにコンパイルするようにしました。