### PR TITLE
Do not call `setContent` because it resets the editor's cursor state. MTC-28657

### DIFF
--- a/mt-static/plugins/TinyMCE6/lib/js/adapter.js
+++ b/mt-static/plugins/TinyMCE6/lib/js/adapter.js
@@ -452,11 +452,6 @@
                 })
             })
 
-            ed.on('SaveContent', function (args) {
-                let content = args.content.replace(/\u00a0/g, '\u0020')
-                ed.setContent(content)
-            })
-
             ed.addCommand('mtSetFormat', function (format) {
                 adapter.manager.setFormat(format)
             })


### PR DESCRIPTION
The removal of "\u00a0" was added in MTC-10735, but this removal is no longer necessary now that IE is no longer supported.