### PR TITLE
Fixed an issue where data label filters would fail. MTC-28871

### DIFF
--- a/lib/MT/ContentData.pm
+++ b/lib/MT/ContentData.pm
@@ -995,7 +995,7 @@ sub list_props {
             display => 'none',
         },
         label => {
-            base    => '__virtual.label',
+            base    => '__virtual.string',
             display => 'force',
         },
         identifier => {


### PR DESCRIPTION
Fixed a bug that caused an error in the data identification label filter when customizing the display of the data_label on the content data list screen with a plugin.