### PR TITLE
Supress uuv more

### DIFF
--- a/lib/MT/App/CMS.pm
+++ b/lib/MT/App/CMS.pm
@@ -3232,6 +3232,7 @@ sub build_menus {
         $menu->{allowed} = 1;
         $menu->{current} = 0;
         $menu->{'id'}    = $id;
+        $menu->{order}   ||= 0;
 
         my @sub_ids = grep {m/^$id:/} keys %$menus;
         my @sub;


### PR DESCRIPTION
トップレベルのメニューのsortの対策です
https://github.com/movabletype/movabletype/blob/fix/uuv_in_build_menus/lib/MT/App/CMS.pm#L3470

```
applications:
  cms:
    menus:
      mymenu:
        label: My Top Level No Order
      entry:no_order:
        label: No Order
```